### PR TITLE
Add gpio functionaliy to lpc845

### DIFF
--- a/lpc82x-hal/src/lib.rs
+++ b/lpc82x-hal/src/lib.rs
@@ -450,7 +450,7 @@ impl Peripherals {
             DMA   : DMA::new(p.DMA),
             // NOTE(unsafe) The init state of the gpio peripheral is enabled,
             // thus it's safe to create an already initialized gpio port
-            GPIO  : unsafe { GPIO::new(p.GPIO_PORT) },
+            GPIO  : unsafe { GPIO::new_enabled(p.GPIO_PORT) },
             I2C0  : I2C::new(p.I2C0),
             PMU   : PMU::new(p.PMU),
             SWM   : SWM::new(p.SWM),

--- a/lpc845-hal/Cargo.toml
+++ b/lpc845-hal/Cargo.toml
@@ -42,3 +42,7 @@ panic-halt  = "0.2.0"
 
 [features]
 rt          = ["lpc845-pac/rt"]
+
+[[example]]
+name              = "gpio"
+required-features = ["rt"]

--- a/lpc845-hal/examples/gpio.rs
+++ b/lpc845-hal/examples/gpio.rs
@@ -24,19 +24,19 @@ fn main() -> ! {
     // let mut wkt = p.WKT.enable(&mut syscon.handle);
     let gpio = p.GPIO.enable(&mut syscon.handle);
 
-    // Configure the PIO0_0 pin. The API tracks the state of pins at
+    // Configure the PIO1_1 pin. The API tracks the state of pins at
     // compile-time, to prevent any mistakes.
-    let mut pio0_0 = swm.pins.pio0_0.into_gpio_pin(&gpio).into_output();
+    let mut pio1_1 = swm.pins.pio1_1.into_gpio_pin(&gpio).into_output();
 
     // Blink the LED
     loop {
         // For this simple demo accurate timing isn't required and this is the
         // simplest Method to delay
         for _ in 0..1000000 {
-            pio0_0.set_high();
+            pio1_1.set_high();
         }
         for _ in 0..1000000 {
-            pio0_0.set_low();
+            pio1_1.set_low();
         }
     }
 }

--- a/lpc845-hal/examples/gpio.rs
+++ b/lpc845-hal/examples/gpio.rs
@@ -1,0 +1,42 @@
+#![no_main]
+#![no_std]
+
+#[allow(unused_imports)]
+use panic_halt;
+
+use lpc845_hal::prelude::*;
+use lpc845_hal::Peripherals;
+
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    // Get access to the device's peripherals. Since only one instance of this
+    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // If we tried to call the method a second time, it would return `None`, but
+    // we're only calling it the one time here, so we can safely `unwrap` the
+    // `Option` without causing a panic.
+    let p = Peripherals::take().unwrap();
+
+    // Initialize the APIs of the peripherals we need.
+    let swm = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
+    // let mut wkt = p.WKT.enable(&mut syscon.handle);
+    let gpio = p.GPIO.enable(&mut syscon.handle);
+
+    // Configure the PIO0_0 pin. The API tracks the state of pins at
+    // compile-time, to prevent any mistakes.
+    let mut pio0_0 = swm.pins.pio0_0.into_gpio_pin(&gpio).into_output();
+
+    // Blink the LED
+    loop {
+        // For this simple demo accurate timing isn't required and this is the
+        // simplest Method to delay
+        for _ in 0..1000000 {
+            pio0_0.set_high();
+        }
+        for _ in 0..1000000 {
+            pio0_0.set_low();
+        }
+    }
+}

--- a/lpc845-hal/src/lib.rs
+++ b/lpc845-hal/src/lib.rs
@@ -6,10 +6,433 @@
 #[cfg(test)]
 extern crate std;
 
-extern crate nb;
-
-extern crate cortex_m;
-extern crate embedded_hal;
-extern crate void;
-
 pub extern crate lpc845_pac as raw;
+pub use lpc8xx_hal_common::*;
+
+pub use self::gpio::GPIO;
+pub use self::swm::SWM;
+pub use self::syscon::SYSCON;
+
+/// Re-exports various traits that are required to use lpc845-hal
+///
+/// The purpose of this module is to improve convenience, by not requiring the
+/// user to import traits separately. Just add the following to your code, and
+/// you should be good to go:
+///
+/// ``` rust
+/// use lpc845_hal::prelude::*;
+/// ```
+///
+/// The traits in this module have been renamed, to avoid collisions with other
+/// imports.
+pub mod prelude {
+    pub use lpc8xx_hal_common::prelude::*;
+}
+
+/// Provides access to all peripherals
+///
+/// This is the entry point to the HAL API. Before you can do anything else, you
+/// need to get an instance of this struct via [`Peripherals::take`] or
+/// [`Peripherals::steal`].
+///
+/// The HAL API tracks the state of peripherals at compile-time, to prevent
+/// potential bugs before the program can even run. Many parts of this
+/// documentation call this "type state". The peripherals available in this
+/// struct are set to their initial state (i.e. their state after a system
+/// reset). See user manual, section 5.6.14.
+///
+/// # Safe Use of the API
+///
+/// Since it should be impossible (outside of unsafe code) to access the
+/// peripherals before this struct is initialized, you can rely on the
+/// peripheral states being correct, as long as there's no bug in the API, and
+/// you're not using unsafe code to do anything that the HAL API can't account
+/// for.
+///
+/// If you directly use unsafe code to access peripherals or manipulate this
+/// API, this will be really obvious from the code. But please note that if
+/// you're using other APIs to access the hardware, such conflicting hardware
+/// access might not be obvious, as the other API might use unsafe code under
+/// the hood to access the hardware (just like this API does).
+///
+/// If you do access the peripherals in any way not intended by this API, please
+/// make sure you know what you're doing. In specific terms, this means you
+/// should be fully aware of what your code does, and whether that is a valid
+/// use of the hardware.
+#[allow(non_snake_case)]
+pub struct Peripherals {
+    /// General-purpose I/O (GPIO)
+    ///
+    /// The GPIO peripheral is enabled by default. See user manual, section
+    /// 5.6.14.
+    pub GPIO: GPIO<init_state::Disabled>,
+
+    /// Switch matrix
+    pub SWM: SWM,
+
+    /// System configuration
+    pub SYSCON: SYSCON,
+
+    /// Self-wake-up timer (WKT)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub WKT: raw::WKT,
+
+    /// Analog comparator
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub ACOMP: raw::ACOMP,
+
+    /// Analog-to-Digital Converter (ADC)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub ADC0: raw::ADC0,
+
+    /// Capacitive Touch (CAPT)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub CAPT: raw::CAPT,
+
+    /// CRC engine
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub CRC: raw::CRC,
+
+    /// Standard counter/timer (CTIMER)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub CTIMER0: raw::CTIMER0,
+
+    /// Digital-to-Analog Converter 0 (DAC0)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub DAC0: raw::DAC0,
+
+    /// Digital-to-Analog Converter 1 (DAC1)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub DAC1: raw::DAC1,
+
+    /// DMA controller
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub DMA0: raw::DMA0,
+
+    /// Flash controller
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub FLASH_CTRL: raw::FLASH_CTRL,
+
+    /// I2C0-bus interface
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub I2C0: raw::I2C0,
+
+    /// I2C1-bus interface
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub I2C1: raw::I2C1,
+
+    /// I2C2-bus interface
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub I2C2: raw::I2C2,
+
+    /// I2C3-bus interface
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub I2C3: raw::I2C3,
+
+    /// Input multiplexing
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub INPUTMUX: raw::INPUTMUX,
+
+    /// I/O configuration
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub IOCON: raw::IOCON,
+
+    /// Multi-Rate Timer (MRT)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub MRT0: raw::MRT0,
+
+    /// Pin interrupt and pattern match engine
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub PINT: raw::PINT,
+
+    /// Power Management Unit
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub PMU: raw::PMU,
+
+    /// State Configurable Timer (SCT)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub SCT0: raw::SCT0,
+
+    /// SPI0
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub SPI0: raw::SPI0,
+
+    /// SPI1
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub SPI1: raw::SPI1,
+
+    /// USART0
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub USART0: raw::USART0,
+
+    /// USART1
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub USART1: raw::USART1,
+
+    /// USART2
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub USART2: raw::USART2,
+
+    /// USART3
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub USART3: raw::USART3,
+
+    /// USART4
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub USART4: raw::USART4,
+
+    /// Windowed Watchdog Timer (WWDT)
+    ///
+    /// A HAL API for this peripheral has not been implemented yet. In the
+    /// meantime, this field provides you with the raw register mappings, which
+    /// allow you full, unprotected access to the peripheral.
+    pub WWDT: raw::WWDT,
+
+    /// CPUID
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub CPUID: raw::CPUID,
+
+    /// Debug Control Block (DCB)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub DCB: raw::DCB,
+
+    /// Data Watchpoint and Trace unit (DWT)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub DWT: raw::DWT,
+
+    /// Memory Protection Unit (MPU)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub MPU: raw::MPU,
+
+    /// Nested Vector Interrupt Controller (NVIC)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub NVIC: raw::NVIC,
+
+    /// System Control Block (SCB)
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub SCB: raw::SCB,
+
+    /// SysTick: System Timer
+    ///
+    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
+    pub SYST: raw::SYST,
+}
+
+impl Peripherals {
+    /// Take the peripherals safely
+    ///
+    /// This method can only be called one time to access the peripherals. It
+    /// will return `Some(Peripherals)` when called for the first time, then
+    /// `None` on any subsequent calls.
+    ///
+    /// Applications should call this method once, at the beginning of their
+    /// main method, to get access to the full API. Any other parts of the
+    /// program should just expect to be passed whatever parts of the HAL API
+    /// they need.
+    ///
+    /// Calling this method from a library is considered an anti-pattern.
+    /// Libraries should just require whatever they need to be passed as
+    /// arguments and leave the initialization to the application that calls
+    /// them.
+    ///
+    /// For an alternative way to gain access to the hardware, please take a
+    /// look at [`Peripherals::steal`].
+    ///
+    /// # Example
+    ///
+    /// ``` no_run
+    /// use lpc845_hal::Peripherals;
+    ///
+    /// // This code should be at the beginning of your program. As long as this
+    /// // is the only place that calls `take`, the following should never
+    /// // panic.
+    /// let p = Peripherals::take().unwrap();
+    /// ```
+    pub fn take() -> Option<Self> {
+        Some(Self::new(
+            raw::Peripherals::take()?,
+            raw::CorePeripherals::take()?,
+        ))
+    }
+
+    /// Steal the peripherals
+    ///
+    /// This function returns an instance of `Peripherals`, whether or not such
+    /// an instance exists somewhere else. This is highly unsafe, as it can lead
+    /// to conflicting access of the hardware, mismatch between actual hardware
+    /// state and peripheral state as tracked by this API at compile-time, and
+    /// in general a full nullification of all safety guarantees that this API
+    /// would normally make.
+    ///
+    /// If at all possible, you should always prefer `Peripherals::take` to this
+    /// method. The only legitimate use of this API is code that can't access
+    /// `Peripherals` the usual way, like a panic handler, or maybe temporary
+    /// debug code in an interrupt handler.
+    ///
+    /// # Safety
+    ///
+    /// This method returns an instance of `Peripherals` that might conflict
+    /// with either other instances of `Peripherals` that exist in the program,
+    /// or other means of accessing the hardware. This is only sure, if you make
+    /// sure of the following:
+    /// 1. No other code can access the hardware at the same time.
+    /// 2. You don't change the hardware state in any way that could invalidate
+    ///    the type state of other `Peripherals` instances.
+    /// 3. The type state in your `Peripherals` instance matches the actual
+    ///    state of the hardware.
+    ///
+    /// Items 1. and 2. are really tricky, so it is recommended to avoid any
+    /// situations where they apply, and restrict the use of this method to
+    /// situations where the program has effectively ended and the hardware will
+    /// be reset right after (like a panic handler).
+    ///
+    /// Item 3. applies to all uses of this method, and is generally very tricky
+    /// to get right. The best way to achieve that is probably to force the API
+    /// into a type state that allows you to execute operations that are known
+    /// to put the hardware in a safe state. Like forcing the type state for a
+    /// peripheral API to the "disabled" state, then enabling it, to make sure
+    /// it is enabled, regardless of wheter it was enabled before.
+    ///
+    /// Since there are no means within this API to forcibly change type state,
+    /// you will need to resort to something like [`core::mem::transmute`].
+    pub unsafe fn steal() -> Self {
+        Self::new(raw::Peripherals::steal(), raw::CorePeripherals::steal())
+    }
+
+    fn new(p: raw::Peripherals, cp: raw::CorePeripherals) -> Self {
+        Peripherals {
+            // HAL peripherals
+            // NOTE(unsafe) The init state of the gpio peripheral is enabled,
+            // thus it's safe to create an already initialized gpio port
+            GPIO: GPIO::new(p.GPIO),
+            SWM: SWM::new(p.SWM0),
+            SYSCON: SYSCON::new(p.SYSCON),
+
+            // Raw peripherals
+            ACOMP: p.ACOMP,
+            ADC0: p.ADC0,
+            CAPT: p.CAPT,
+            CRC: p.CRC,
+            CTIMER0: p.CTIMER0,
+            DAC0: p.DAC0,
+            DAC1: p.DAC1,
+            DMA0: p.DMA0,
+            FLASH_CTRL: p.FLASH_CTRL,
+            I2C0: p.I2C0,
+            I2C1: p.I2C1,
+            I2C2: p.I2C2,
+            I2C3: p.I2C3,
+            INPUTMUX: p.INPUTMUX,
+            IOCON: p.IOCON,
+            MRT0: p.MRT0,
+            PINT: p.PINT,
+            PMU: p.PMU,
+            SCT0: p.SCT0,
+            SPI0: p.SPI0,
+            SPI1: p.SPI1,
+            USART0: p.USART0,
+            USART1: p.USART1,
+            USART2: p.USART2,
+            USART3: p.USART3,
+            USART4: p.USART4,
+            WKT: p.WKT,
+            WWDT: p.WWDT,
+
+            // Core peripherals
+            CPUID: cp.CPUID,
+            DCB: cp.DCB,
+            DWT: cp.DWT,
+            MPU: cp.MPU,
+            NVIC: cp.NVIC,
+            SCB: cp.SCB,
+            SYST: cp.SYST,
+        }
+    }
+}

--- a/lpc8xx-hal-common/src/gpio.rs
+++ b/lpc8xx-hal-common/src/gpio.rs
@@ -61,7 +61,7 @@ impl GPIO<init_state::Enabled> {
     /// [`Enabled`] state. It's up to the caller to verify this assumption.
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub unsafe fn new(gpio: raw_compat::GPIO) -> Self {
+    pub unsafe fn new_enabled(gpio: raw_compat::GPIO) -> Self {
         GPIO {
             gpio: gpio,
             _state: init_state::Enabled(()),
@@ -70,6 +70,20 @@ impl GPIO<init_state::Enabled> {
 }
 
 impl GPIO<init_state::Disabled> {
+    /// Create an disabled gpio peripheral
+    ///
+    /// This method creates an `GPIO` instance that it assumes is in the
+    /// [`Disabled`] state. As it's only possible to enable a [`Disabled`] `GPIO`
+    /// instance, it's also safe to pass an already [`Enabled`] instance.
+    ///
+    /// [`Disabled`]: ../init_state/struct.Enabled.html
+    /// [`Enabled`]: ../init_state/struct.Enabled.html
+    pub fn new(gpio: raw_compat::GPIO) -> Self {
+        GPIO {
+            gpio: gpio,
+            _state: init_state::Disabled,
+        }
+    }
     /// Enable the GPIO peripheral
     ///
     /// This method is only available, if `GPIO` is in the [`Disabled`] state.

--- a/lpc8xx-hal-common/src/gpio.rs
+++ b/lpc8xx-hal-common/src/gpio.rs
@@ -32,7 +32,7 @@
 use embedded_hal::digital::{OutputPin, StatefulOutputPin};
 
 use crate::{
-    init_state, raw,
+    init_state, raw_compat,
     swm::{pin_state, Pin, PinTrait},
     syscon,
 };
@@ -50,7 +50,7 @@ use crate::{
 /// [`Peripherals`]: ../struct.Peripherals.html
 /// [module documentation]: index.html
 pub struct GPIO<State = init_state::Enabled> {
-    pub(crate) gpio: raw::GPIO_PORT,
+    pub(crate) gpio: raw_compat::GPIO,
     _state: State,
 }
 
@@ -61,7 +61,7 @@ impl GPIO<init_state::Enabled> {
     /// [`Enabled`] state. It's up to the caller to verify this assumption.
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub unsafe fn new(gpio: raw::GPIO_PORT) -> Self {
+    pub unsafe fn new(gpio: raw_compat::GPIO) -> Self {
         GPIO {
             gpio: gpio,
             _state: init_state::Enabled(()),
@@ -126,7 +126,7 @@ impl<State> GPIO<State> {
     /// prioritize it accordingly.
     ///
     /// [open an issue]: https://github.com/lpc-rs/lpc8xx-hal/issues
-    pub fn free(self) -> raw::GPIO_PORT {
+    pub fn free(self) -> raw_compat::GPIO {
         self.gpio
     }
 }

--- a/lpc8xx-hal-common/src/gpio.rs
+++ b/lpc8xx-hal-common/src/gpio.rs
@@ -179,18 +179,16 @@ where
     /// pin.set_low();
     /// ```
     pub fn into_output(self) -> Pin<T, pin_state::Gpio<'gpio, direction::Output>> {
-        self.state
-            .dirset0
-            .write(|w| unsafe { w.dirsetp().bits(T::MASK) });
+        self.state.dirset[T::PORT].write(|w| unsafe { w.dirsetp().bits(T::MASK) });
 
         Pin {
             ty: self.ty,
 
             state: pin_state::Gpio {
-                dirset0: self.state.dirset0,
-                pin0: self.state.pin0,
-                set0: self.state.set0,
-                clr0: self.state.clr0,
+                dirset: self.state.dirset,
+                pin: self.state.pin,
+                set: self.state.set,
+                clr: self.state.clr,
 
                 _direction: direction::Output,
             },
@@ -214,7 +212,7 @@ where
     /// [`into_gpio_pin`]: #method.into_gpio_pin
     /// [`into_output`]: #method.into_output
     fn set_high(&mut self) {
-        self.state.set0.write(|w| unsafe { w.setp().bits(T::MASK) })
+        self.state.set[T::PORT].write(|w| unsafe { w.setp().bits(T::MASK) })
     }
 
     /// Set the pin output to LOW
@@ -229,7 +227,7 @@ where
     /// [`into_gpio_pin`]: #method.into_gpio_pin
     /// [`into_output`]: #method.into_output
     fn set_low(&mut self) {
-        self.state.clr0.write(|w| unsafe { w.clrp().bits(T::MASK) });
+        self.state.clr[T::PORT].write(|w| unsafe { w.clrp().bits(T::MASK) });
     }
 }
 
@@ -249,7 +247,7 @@ where
     /// [`into_gpio_pin`]: #method.into_gpio_pin
     /// [`into_output`]: #method.into_output
     fn is_set_high(&self) -> bool {
-        self.state.pin0.read().port().bits() & T::MASK == T::MASK
+        self.state.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
     }
 
     /// Indicates whether the pin output is currently set to LOW
@@ -264,7 +262,7 @@ where
     /// [`into_gpio_pin`]: #method.into_gpio_pin
     /// [`into_output`]: #method.into_output
     fn is_set_low(&self) -> bool {
-        !self.state.pin0.read().port().bits() & T::MASK == T::MASK
+        !self.state.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
     }
 }
 

--- a/lpc8xx-hal-common/src/lib.rs
+++ b/lpc8xx-hal-common/src/lib.rs
@@ -8,11 +8,8 @@ pub use lpc82x_pac as raw;
 pub use lpc845_pac as raw;
 
 pub mod clock;
-#[cfg(feature = "82x")]
 pub mod gpio;
-#[cfg(feature = "82x")]
 pub mod swm;
-#[cfg(feature = "82x")]
 pub mod syscon;
 #[macro_use]
 pub(crate) mod reg_proxy;
@@ -40,4 +37,45 @@ pub mod init_state {
 
     /// Indicates that the hardware component is disabled
     pub struct Disabled;
+}
+
+// Provide common peripheral names
+// When in doubt, use the names from the new svd files
+mod raw_compat {
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::gpio;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::gpio_port as gpio;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::ACOMP;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::ADC as ADC0;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::ADC0;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::CMP as ACOMP;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::DMA as DMA0;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::DMA0;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::FLASHCTRL as FLASH_CTRL;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::FLASH_CTRL;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::GPIO;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::GPIO_PORT as GPIO;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::MRT as MRT0;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::MRT0;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::SCT as SCT0;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::SCT0;
+    #[cfg(feature = "82x")]
+    pub(crate) use crate::raw::SWM as SWM0;
+    #[cfg(feature = "845")]
+    pub(crate) use crate::raw::SWM0;
 }

--- a/lpc8xx-hal-common/src/reg_proxy.rs
+++ b/lpc8xx-hal-common/src/reg_proxy.rs
@@ -8,8 +8,6 @@
 //! This module works around this limitation, by introducing a proxy struct that
 //! provides access to a register.
 
-// TODO Remove when lpc845 functionality is added
-#![allow(dead_code)]
 use core::marker::PhantomData;
 use core::mem::transmute;
 use core::ops::Deref;

--- a/lpc8xx-hal-common/src/swm.rs
+++ b/lpc8xx-hal-common/src/swm.rs
@@ -339,7 +339,7 @@ pins!(
 ///   general-purpose I/O
 /// - [`pin_state::Swm`], to indicate that the pin is available for switch
 ///   matrix function assignment
-/// - [`pin_state::Adc`], to indicate that the pin is being used for analog
+/// - [`pin_state::Analog`], to indicate that the pin is being used for analog
 ///   input
 ///
 /// # State Management
@@ -700,17 +700,17 @@ where
     }
 }
 
-impl<T, F> AssignFunction<F, Adc> for Pin<T, pin_state::Swm<(), ()>>
+impl<T, F> AssignFunction<F, Analog> for Pin<T, pin_state::Swm<(), ()>>
 where
     T: PinTrait,
-    F: FunctionTrait<T, Kind = Adc>,
+    F: FunctionTrait<T, Kind = Analog>,
 {
-    type Assigned = Pin<T, pin_state::Adc>;
+    type Assigned = Pin<T, pin_state::Analog>;
 
     fn assign(self) -> Self::Assigned {
         Pin {
             ty: self.ty,
-            state: pin_state::Adc,
+            state: pin_state::Analog,
         }
     }
 }
@@ -747,9 +747,9 @@ pub mod pin_state {
     /// Marks a [`Pin`]  as being assigned to the analog-to-digital converter
     ///
     /// [`Pin`]: ../struct.Pin.html
-    pub struct Adc;
+    pub struct Analog;
 
-    impl PinState for Adc {}
+    impl PinState for Analog {}
 
     /// Marks a [`Pin`]  as being assigned to general-purpose I/O
     ///
@@ -991,9 +991,9 @@ impl FunctionKind for Input {}
 pub struct Output;
 impl FunctionKind for Output {}
 
-/// Designates an SWM function as an ADC function
-pub struct Adc;
-impl FunctionKind for Adc {}
+/// Designates an SWM function as an analog function
+pub struct Analog;
+impl FunctionKind for Analog {}
 
 /// Internal trait used to assign functions to pins
 ///
@@ -1342,18 +1342,18 @@ fixed_functions!(
     VDDCMP  , Input , vddcmp  , PIO0_6 , state::Unassigned;
     I2C0_SDA, Output, i2c0_sda, PIO0_11, state::Unassigned;
     I2C0_SCL, Output, i2c0_scl, PIO0_10, state::Unassigned;
-    ADC_0   , Adc   , adc_0   , PIO0_7 , state::Unassigned;
-    ADC_1   , Adc   , adc_1   , PIO0_6 , state::Unassigned;
-    ADC_2   , Adc   , adc_2   , PIO0_14, state::Unassigned;
-    ADC_3   , Adc   , adc_3   , PIO0_23, state::Unassigned;
-    ADC_4   , Adc   , adc_4   , PIO0_22, state::Unassigned;
-    ADC_5   , Adc   , adc_5   , PIO0_21, state::Unassigned;
-    ADC_6   , Adc   , adc_6   , PIO0_20, state::Unassigned;
-    ADC_7   , Adc   , adc_7   , PIO0_19, state::Unassigned;
-    ADC_8   , Adc   , adc_8   , PIO0_18, state::Unassigned;
-    ADC_9   , Adc   , adc_9   , PIO0_17, state::Unassigned;
-    ADC_10  , Adc   , adc_10  , PIO0_13, state::Unassigned;
-    ADC_11  , Adc   , adc_11  , PIO0_4 , state::Unassigned;
+    ADC_0   , Analog, adc_0   , PIO0_7 , state::Unassigned;
+    ADC_1   , Analog, adc_1   , PIO0_6 , state::Unassigned;
+    ADC_2   , Analog, adc_2   , PIO0_14, state::Unassigned;
+    ADC_3   , Analog, adc_3   , PIO0_23, state::Unassigned;
+    ADC_4   , Analog, adc_4   , PIO0_22, state::Unassigned;
+    ADC_5   , Analog, adc_5   , PIO0_21, state::Unassigned;
+    ADC_6   , Analog, adc_6   , PIO0_20, state::Unassigned;
+    ADC_7   , Analog, adc_7   , PIO0_19, state::Unassigned;
+    ADC_8   , Analog, adc_8   , PIO0_18, state::Unassigned;
+    ADC_9   , Analog, adc_9   , PIO0_17, state::Unassigned;
+    ADC_10  , Analog, adc_10  , PIO0_13, state::Unassigned;
+    ADC_11  , Analog, adc_11  , PIO0_4 , state::Unassigned;
 );
 
 #[cfg(feature = "845")]
@@ -1372,33 +1372,32 @@ fixed_functions!(
     VDDCMP  , Input , vddcmp  , PIO0_6 , state::Unassigned;
     I2C0_SDA, Output, i2c0_sda, PIO0_11, state::Unassigned;
     I2C0_SCL, Output, i2c0_scl, PIO0_10, state::Unassigned;
-    ADC_0   , Adc   , adc_0   , PIO0_7 , state::Unassigned;
-    ADC_1   , Adc   , adc_1   , PIO0_6 , state::Unassigned;
-    ADC_2   , Adc   , adc_2   , PIO0_14, state::Unassigned;
-    ADC_3   , Adc   , adc_3   , PIO0_23, state::Unassigned;
-    ADC_4   , Adc   , adc_4   , PIO0_22, state::Unassigned;
-    ADC_5   , Adc   , adc_5   , PIO0_21, state::Unassigned;
-    ADC_6   , Adc   , adc_6   , PIO0_20, state::Unassigned;
-    ADC_7   , Adc   , adc_7   , PIO0_19, state::Unassigned;
-    ADC_8   , Adc   , adc_8   , PIO0_18, state::Unassigned;
-    ADC_9   , Adc   , adc_9   , PIO0_17, state::Unassigned;
-    ADC_10  , Adc   , adc_10  , PIO0_13, state::Unassigned;
-    ADC_11  , Adc   , adc_11  , PIO0_4 , state::Unassigned;
-    DACOUT0 , Adc   , dacout0 , PIO0_17, state::Unassigned;
-    DACOUT1 , Adc   , dacout1 , PIO0_29, state::Unassigned;
-    // TODO Is it input or output?
-    CAPT_X0 , Adc   , capt_x0 , PIO0_31, state::Unassigned;
-    // CAPT_X1 , Adc   , capt_x1 , PIO1_0 , state::Unassigned;
-    // CAPT_X2 , Adc   , capt_x2 , PIO1_1 , state::Unassigned;
-    // CAPT_X3 , Adc   , capt_x3 , PIO1_2 , state::Unassigned;
-    // pinenable1
-    // CAPT_X4 , Adc   , capt_x4 , PIO1_3 , state::Unassigned;
-    // CAPT_X5 , Adc   , capt_x5 , PIO1_4 , state::Unassigned;
-    // CAPT_X6 , Adc   , capt_x6 , PIO1_5 , state::Unassigned;
-    // CAPT_X7 , Adc   , capt_x7 , PIO1_6 , state::Unassigned;
-    // CAPT_X8 , Adc   , capt_x8 , PIO1_7 , state::Unassigned;
-    // CAPT_YL , Adc   , capt_yl , PIO1_8 , state::Unassigned;
-    // CAPT_YH , Adc   , capt_yh , PIO1_8 , state::Unassigned;
+    ADC_0   , Analog, adc_0   , PIO0_7 , state::Unassigned;
+    ADC_1   , Analog, adc_1   , PIO0_6 , state::Unassigned;
+    ADC_2   , Analog, adc_2   , PIO0_14, state::Unassigned;
+    ADC_3   , Analog, adc_3   , PIO0_23, state::Unassigned;
+    ADC_4   , Analog, adc_4   , PIO0_22, state::Unassigned;
+    ADC_5   , Analog, adc_5   , PIO0_21, state::Unassigned;
+    ADC_6   , Analog, adc_6   , PIO0_20, state::Unassigned;
+    ADC_7   , Analog, adc_7   , PIO0_19, state::Unassigned;
+    ADC_8   , Analog, adc_8   , PIO0_18, state::Unassigned;
+    ADC_9   , Analog, adc_9   , PIO0_17, state::Unassigned;
+    ADC_10  , Analog, adc_10  , PIO0_13, state::Unassigned;
+    ADC_11  , Analog, adc_11  , PIO0_4 , state::Unassigned;
+    DACOUT0 , Analog, dacout0 , PIO0_17, state::Unassigned;
+    DACOUT1 , Analog, dacout1 , PIO0_29, state::Unassigned;
+    CAPT_X0 , Analog, capt_x0 , PIO0_31, state::Unassigned;
+    // CAPT_X1 , Analog, capt_x1 , PIO1_0 , state::Unassigned;
+    // CAPT_X2 , Analog, capt_x2 , PIO1_1 , state::Unassigned;
+    // CAPT_X3 , Analog, capt_x3 , PIO1_2 , state::Unassigned;
+    // TODO pinenable1
+    // CAPT_X4 , Analog, capt_x4 , PIO1_3 , state::Unassigned;
+    // CAPT_X5 , Analog, capt_x5 , PIO1_4 , state::Unassigned;
+    // CAPT_X6 , Analog, capt_x6 , PIO1_5 , state::Unassigned;
+    // CAPT_X7 , Analog, capt_x7 , PIO1_6 , state::Unassigned;
+    // CAPT_X8 , Analog, capt_x8 , PIO1_7 , state::Unassigned;
+    // CAPT_YL , Analog, capt_yl , PIO1_8 , state::Unassigned;
+    // CAPT_YH , Analog, capt_yh , PIO1_8 , state::Unassigned;
 );
 
 /// Contains types that indicate the state of fixed or movable functions

--- a/lpc8xx-hal-common/src/swm.rs
+++ b/lpc8xx-hal-common/src/swm.rs
@@ -166,6 +166,10 @@ impl Handle<init_state::Enabled> {
 ///
 /// Please refer to [`Pin`] for the public API used to control pins.
 pub trait PinTrait {
+    /// A number that indentifies the port
+    ///
+    /// This is `0` for [`PIO0_0`] and `1` for [`PIO1_0`]
+    const PORT: usize;
     /// A number that identifies the pin
     ///
     /// This is `0` for [`PIO0_0`], `1` for [`PIO0_1`] and so forth.
@@ -182,6 +186,7 @@ macro_rules! pins {
     ($(
         $field:ident,
         $type:ident,
+        $port:expr,
         $id:expr,
         $default_state_ty:ty,
         $default_state_val:expr;
@@ -227,8 +232,9 @@ macro_rules! pins {
             pub struct $type(());
 
             impl PinTrait for $type {
-                const ID  : u8  = $id;
-                const MASK: u32 = 0x1 << $id;
+                const PORT: usize = $port;
+                const ID  : u8    = $id;
+                const MASK: u32   = 0x1 << $id;
             }
         )*
     }
@@ -236,94 +242,93 @@ macro_rules! pins {
 
 #[cfg(feature = "82x")]
 pins!(
-    pio0_0 , PIO0_0 , 0x00, pin_state::Unused        , pin_state::Unused;
-    pio0_1 , PIO0_1 , 0x01, pin_state::Unused        , pin_state::Unused;
-    pio0_2 , PIO0_2 , 0x02, pin_state::Swm<((),), ()>, pin_state::Swm::new();
-    pio0_3 , PIO0_3 , 0x03, pin_state::Swm<((),), ()>, pin_state::Swm::new();
-    pio0_4 , PIO0_4 , 0x04, pin_state::Unused        , pin_state::Unused;
-    pio0_5 , PIO0_5 , 0x05, pin_state::Swm<(), ((),)>, pin_state::Swm::new();
-    pio0_6 , PIO0_6 , 0x06, pin_state::Unused        , pin_state::Unused;
-    pio0_7 , PIO0_7 , 0x07, pin_state::Unused        , pin_state::Unused;
-    pio0_8 , PIO0_8 , 0x08, pin_state::Unused        , pin_state::Unused;
-    pio0_9 , PIO0_9 , 0x09, pin_state::Unused        , pin_state::Unused;
-    pio0_10, PIO0_10, 0x0a, pin_state::Unused        , pin_state::Unused;
-    pio0_11, PIO0_11, 0x0b, pin_state::Unused        , pin_state::Unused;
-    pio0_12, PIO0_12, 0x0c, pin_state::Unused        , pin_state::Unused;
-    pio0_13, PIO0_13, 0x0d, pin_state::Unused        , pin_state::Unused;
-    pio0_14, PIO0_14, 0x0e, pin_state::Unused        , pin_state::Unused;
-    pio0_15, PIO0_15, 0x0f, pin_state::Unused        , pin_state::Unused;
-    pio0_16, PIO0_16, 0x10, pin_state::Unused        , pin_state::Unused;
-    pio0_17, PIO0_17, 0x11, pin_state::Unused        , pin_state::Unused;
-    pio0_18, PIO0_18, 0x12, pin_state::Unused        , pin_state::Unused;
-    pio0_19, PIO0_19, 0x13, pin_state::Unused        , pin_state::Unused;
-    pio0_20, PIO0_20, 0x14, pin_state::Unused        , pin_state::Unused;
-    pio0_21, PIO0_21, 0x15, pin_state::Unused        , pin_state::Unused;
-    pio0_22, PIO0_22, 0x16, pin_state::Unused        , pin_state::Unused;
-    pio0_23, PIO0_23, 0x17, pin_state::Unused        , pin_state::Unused;
-    pio0_24, PIO0_24, 0x18, pin_state::Unused        , pin_state::Unused;
-    pio0_25, PIO0_25, 0x19, pin_state::Unused        , pin_state::Unused;
-    pio0_26, PIO0_26, 0x1a, pin_state::Unused        , pin_state::Unused;
-    pio0_27, PIO0_27, 0x1b, pin_state::Unused        , pin_state::Unused;
-    pio0_28, PIO0_28, 0x1c, pin_state::Unused        , pin_state::Unused;
+    pio0_0 , PIO0_0 , 0, 0x00, pin_state::Unused        , pin_state::Unused;
+    pio0_1 , PIO0_1 , 0, 0x01, pin_state::Unused        , pin_state::Unused;
+    pio0_2 , PIO0_2 , 0, 0x02, pin_state::Swm<((),), ()>, pin_state::Swm::new();
+    pio0_3 , PIO0_3 , 0, 0x03, pin_state::Swm<((),), ()>, pin_state::Swm::new();
+    pio0_4 , PIO0_4 , 0, 0x04, pin_state::Unused        , pin_state::Unused;
+    pio0_5 , PIO0_5 , 0, 0x05, pin_state::Swm<(), ((),)>, pin_state::Swm::new();
+    pio0_6 , PIO0_6 , 0, 0x06, pin_state::Unused        , pin_state::Unused;
+    pio0_7 , PIO0_7 , 0, 0x07, pin_state::Unused        , pin_state::Unused;
+    pio0_8 , PIO0_8 , 0, 0x08, pin_state::Unused        , pin_state::Unused;
+    pio0_9 , PIO0_9 , 0, 0x09, pin_state::Unused        , pin_state::Unused;
+    pio0_10, PIO0_10, 0, 0x0a, pin_state::Unused        , pin_state::Unused;
+    pio0_11, PIO0_11, 0, 0x0b, pin_state::Unused        , pin_state::Unused;
+    pio0_12, PIO0_12, 0, 0x0c, pin_state::Unused        , pin_state::Unused;
+    pio0_13, PIO0_13, 0, 0x0d, pin_state::Unused        , pin_state::Unused;
+    pio0_14, PIO0_14, 0, 0x0e, pin_state::Unused        , pin_state::Unused;
+    pio0_15, PIO0_15, 0, 0x0f, pin_state::Unused        , pin_state::Unused;
+    pio0_16, PIO0_16, 0, 0x10, pin_state::Unused        , pin_state::Unused;
+    pio0_17, PIO0_17, 0, 0x11, pin_state::Unused        , pin_state::Unused;
+    pio0_18, PIO0_18, 0, 0x12, pin_state::Unused        , pin_state::Unused;
+    pio0_19, PIO0_19, 0, 0x13, pin_state::Unused        , pin_state::Unused;
+    pio0_20, PIO0_20, 0, 0x14, pin_state::Unused        , pin_state::Unused;
+    pio0_21, PIO0_21, 0, 0x15, pin_state::Unused        , pin_state::Unused;
+    pio0_22, PIO0_22, 0, 0x16, pin_state::Unused        , pin_state::Unused;
+    pio0_23, PIO0_23, 0, 0x17, pin_state::Unused        , pin_state::Unused;
+    pio0_24, PIO0_24, 0, 0x18, pin_state::Unused        , pin_state::Unused;
+    pio0_25, PIO0_25, 0, 0x19, pin_state::Unused        , pin_state::Unused;
+    pio0_26, PIO0_26, 0, 0x1a, pin_state::Unused        , pin_state::Unused;
+    pio0_27, PIO0_27, 0, 0x1b, pin_state::Unused        , pin_state::Unused;
+    pio0_28, PIO0_28, 0, 0x1c, pin_state::Unused        , pin_state::Unused;
 );
 
 #[cfg(feature = "845")]
 pins!(
-    pio0_0 , PIO0_0 , 0x00, pin_state::Unused        , pin_state::Unused;
-    pio0_1 , PIO0_1 , 0x01, pin_state::Unused        , pin_state::Unused;
-    pio0_2 , PIO0_2 , 0x02, pin_state::Swm<((),), ()>, pin_state::Swm::new();
-    pio0_3 , PIO0_3 , 0x03, pin_state::Swm<((),), ()>, pin_state::Swm::new();
-    pio0_4 , PIO0_4 , 0x04, pin_state::Unused        , pin_state::Unused;
-    pio0_5 , PIO0_5 , 0x05, pin_state::Swm<(), ((),)>, pin_state::Swm::new();
-    pio0_6 , PIO0_6 , 0x06, pin_state::Unused        , pin_state::Unused;
-    pio0_7 , PIO0_7 , 0x07, pin_state::Unused        , pin_state::Unused;
-    pio0_8 , PIO0_8 , 0x08, pin_state::Unused        , pin_state::Unused;
-    pio0_9 , PIO0_9 , 0x09, pin_state::Unused        , pin_state::Unused;
-    pio0_10, PIO0_10, 0x0a, pin_state::Unused        , pin_state::Unused;
-    pio0_11, PIO0_11, 0x0b, pin_state::Unused        , pin_state::Unused;
-    pio0_12, PIO0_12, 0x0c, pin_state::Unused        , pin_state::Unused;
-    pio0_13, PIO0_13, 0x0d, pin_state::Unused        , pin_state::Unused;
-    pio0_14, PIO0_14, 0x0e, pin_state::Unused        , pin_state::Unused;
-    pio0_15, PIO0_15, 0x0f, pin_state::Unused        , pin_state::Unused;
-    pio0_16, PIO0_16, 0x10, pin_state::Unused        , pin_state::Unused;
-    pio0_17, PIO0_17, 0x11, pin_state::Unused        , pin_state::Unused;
-    pio0_18, PIO0_18, 0x12, pin_state::Unused        , pin_state::Unused;
-    pio0_19, PIO0_19, 0x13, pin_state::Unused        , pin_state::Unused;
-    pio0_20, PIO0_20, 0x14, pin_state::Unused        , pin_state::Unused;
-    pio0_21, PIO0_21, 0x15, pin_state::Unused        , pin_state::Unused;
-    pio0_22, PIO0_22, 0x16, pin_state::Unused        , pin_state::Unused;
-    pio0_23, PIO0_23, 0x17, pin_state::Unused        , pin_state::Unused;
-    pio0_24, PIO0_24, 0x18, pin_state::Unused        , pin_state::Unused;
-    pio0_25, PIO0_25, 0x19, pin_state::Unused        , pin_state::Unused;
-    pio0_26, PIO0_26, 0x1a, pin_state::Unused        , pin_state::Unused;
-    pio0_27, PIO0_27, 0x1b, pin_state::Unused        , pin_state::Unused;
-    pio0_28, PIO0_28, 0x1c, pin_state::Unused        , pin_state::Unused;
-    pio0_29, PIO0_29, 0x1d, pin_state::Unused        , pin_state::Unused;
-    pio0_30, PIO0_30, 0x1e, pin_state::Unused        , pin_state::Unused;
-    pio0_31, PIO0_31, 0x1f, pin_state::Unused        , pin_state::Unused;
-    // TODO this is on gpio1
-    // pio1_0 , PIO1_0 , 0x00, pin_state::Unused        , pin_state::Unused;
-    // pio1_1 , PIO1_1 , 0x01, pin_state::Unused        , pin_state::Unused;
-    // pio1_2 , PIO1_2 , 0x02, pin_state::Unusetd       , pin_state::Unused;
-    // pio1_3 , PIO1_3 , 0x03, pin_state::Unusetd       , pin_state::Unused;
-    // pio1_4 , PIO1_4 , 0x04, pin_state::Unused        , pin_state::Unused;
-    // pio1_5 , PIO1_5 , 0x05, pin_state::Unusetd       , pin_state::Unused;
-    // pio1_6 , PIO1_6 , 0x06, pin_state::Unused        , pin_state::Unused;
-    // pio1_7 , PIO1_7 , 0x07, pin_state::Unused        , pin_state::Unused;
-    // pio1_8 , PIO1_8 , 0x08, pin_state::Unused        , pin_state::Unused;
-    // pio1_9 , PIO1_9 , 0x09, pin_state::Unused        , pin_state::Unused;
-    // pio1_10, PIO1_10, 0x0a, pin_state::Unused        , pin_state::Unused;
-    // pio1_11, PIO1_11, 0x0b, pin_state::Unused        , pin_state::Unused;
-    // pio1_12, PIO1_12, 0x0c, pin_state::Unused        , pin_state::Unused;
-    // pio1_13, PIO1_13, 0x0d, pin_state::Unused        , pin_state::Unused;
-    // pio1_14, PIO1_14, 0x0e, pin_state::Unused        , pin_state::Unused;
-    // pio1_15, PIO1_15, 0x0f, pin_state::Unused        , pin_state::Unused;
-    // pio1_16, PIO1_16, 0x10, pin_state::Unused        , pin_state::Unused;
-    // pio1_17, PIO1_17, 0x11, pin_state::Unused        , pin_state::Unused;
-    // pio1_18, PIO1_18, 0x12, pin_state::Unused        , pin_state::Unused;
-    // pio1_19, PIO1_19, 0x13, pin_state::Unused        , pin_state::Unused;
-    // pio1_20, PIO1_20, 0x14, pin_state::Unused        , pin_state::Unused;
-    // pio1_21, PIO1_21, 0x15, pin_state::Unused        , pin_state::Unused;
+    pio0_0 , PIO0_0 , 0, 0x00, pin_state::Unused        , pin_state::Unused;
+    pio0_1 , PIO0_1 , 0, 0x01, pin_state::Unused        , pin_state::Unused;
+    pio0_2 , PIO0_2 , 0, 0x02, pin_state::Swm<((),), ()>, pin_state::Swm::new();
+    pio0_3 , PIO0_3 , 0, 0x03, pin_state::Swm<((),), ()>, pin_state::Swm::new();
+    pio0_4 , PIO0_4 , 0, 0x04, pin_state::Unused        , pin_state::Unused;
+    pio0_5 , PIO0_5 , 0, 0x05, pin_state::Swm<(), ((),)>, pin_state::Swm::new();
+    pio0_6 , PIO0_6 , 0, 0x06, pin_state::Unused        , pin_state::Unused;
+    pio0_7 , PIO0_7 , 0, 0x07, pin_state::Unused        , pin_state::Unused;
+    pio0_8 , PIO0_8 , 0, 0x08, pin_state::Unused        , pin_state::Unused;
+    pio0_9 , PIO0_9 , 0, 0x09, pin_state::Unused        , pin_state::Unused;
+    pio0_10, PIO0_10, 0, 0x0a, pin_state::Unused        , pin_state::Unused;
+    pio0_11, PIO0_11, 0, 0x0b, pin_state::Unused        , pin_state::Unused;
+    pio0_12, PIO0_12, 0, 0x0c, pin_state::Unused        , pin_state::Unused;
+    pio0_13, PIO0_13, 0, 0x0d, pin_state::Unused        , pin_state::Unused;
+    pio0_14, PIO0_14, 0, 0x0e, pin_state::Unused        , pin_state::Unused;
+    pio0_15, PIO0_15, 0, 0x0f, pin_state::Unused        , pin_state::Unused;
+    pio0_16, PIO0_16, 0, 0x10, pin_state::Unused        , pin_state::Unused;
+    pio0_17, PIO0_17, 0, 0x11, pin_state::Unused        , pin_state::Unused;
+    pio0_18, PIO0_18, 0, 0x12, pin_state::Unused        , pin_state::Unused;
+    pio0_19, PIO0_19, 0, 0x13, pin_state::Unused        , pin_state::Unused;
+    pio0_20, PIO0_20, 0, 0x14, pin_state::Unused        , pin_state::Unused;
+    pio0_21, PIO0_21, 0, 0x15, pin_state::Unused        , pin_state::Unused;
+    pio0_22, PIO0_22, 0, 0x16, pin_state::Unused        , pin_state::Unused;
+    pio0_23, PIO0_23, 0, 0x17, pin_state::Unused        , pin_state::Unused;
+    pio0_24, PIO0_24, 0, 0x18, pin_state::Unused        , pin_state::Unused;
+    pio0_25, PIO0_25, 0, 0x19, pin_state::Unused        , pin_state::Unused;
+    pio0_26, PIO0_26, 0, 0x1a, pin_state::Unused        , pin_state::Unused;
+    pio0_27, PIO0_27, 0, 0x1b, pin_state::Unused        , pin_state::Unused;
+    pio0_28, PIO0_28, 0, 0x1c, pin_state::Unused        , pin_state::Unused;
+    pio0_29, PIO0_29, 0, 0x1d, pin_state::Unused        , pin_state::Unused;
+    pio0_30, PIO0_30, 0, 0x1e, pin_state::Unused        , pin_state::Unused;
+    pio0_31, PIO0_31, 0, 0x1f, pin_state::Unused        , pin_state::Unused;
+    pio1_0 , PIO1_0 , 1, 0x00, pin_state::Unused        , pin_state::Unused;
+    pio1_1 , PIO1_1 , 1, 0x01, pin_state::Unused        , pin_state::Unused;
+    pio1_2 , PIO1_2 , 1, 0x02, pin_state::Unused        , pin_state::Unused;
+    pio1_3 , PIO1_3 , 1, 0x03, pin_state::Unused        , pin_state::Unused;
+    pio1_4 , PIO1_4 , 1, 0x04, pin_state::Unused        , pin_state::Unused;
+    pio1_5 , PIO1_5 , 1, 0x05, pin_state::Unused        , pin_state::Unused;
+    pio1_6 , PIO1_6 , 1, 0x06, pin_state::Unused        , pin_state::Unused;
+    pio1_7 , PIO1_7 , 1, 0x07, pin_state::Unused        , pin_state::Unused;
+    pio1_8 , PIO1_8 , 1, 0x08, pin_state::Unused        , pin_state::Unused;
+    pio1_9 , PIO1_9 , 1, 0x09, pin_state::Unused        , pin_state::Unused;
+    pio1_10, PIO1_10, 1, 0x0a, pin_state::Unused        , pin_state::Unused;
+    pio1_11, PIO1_11, 1, 0x0b, pin_state::Unused        , pin_state::Unused;
+    pio1_12, PIO1_12, 1, 0x0c, pin_state::Unused        , pin_state::Unused;
+    pio1_13, PIO1_13, 1, 0x0d, pin_state::Unused        , pin_state::Unused;
+    pio1_14, PIO1_14, 1, 0x0e, pin_state::Unused        , pin_state::Unused;
+    pio1_15, PIO1_15, 1, 0x0f, pin_state::Unused        , pin_state::Unused;
+    pio1_16, PIO1_16, 1, 0x10, pin_state::Unused        , pin_state::Unused;
+    pio1_17, PIO1_17, 1, 0x11, pin_state::Unused        , pin_state::Unused;
+    pio1_18, PIO1_18, 1, 0x12, pin_state::Unused        , pin_state::Unused;
+    pio1_19, PIO1_19, 1, 0x13, pin_state::Unused        , pin_state::Unused;
+    pio1_20, PIO1_20, 1, 0x14, pin_state::Unused        , pin_state::Unused;
+    pio1_21, PIO1_21, 1, 0x15, pin_state::Unused        , pin_state::Unused;
 );
 
 /// Main API to control for controlling pins
@@ -553,24 +558,26 @@ where
     ///
     /// [State Management]: #state-management
     pub fn into_gpio_pin(self, gpio: &GPIO) -> Pin<T, pin_state::Gpio<gpio::direction::Unknown>> {
+        // Isn't used for lpc845
+        #[allow(unused_imports)]
+        use core::slice;
         Pin {
             ty: self.ty,
             #[cfg(feature = "82x")]
             state: pin_state::Gpio {
-                dirset0: &gpio.gpio.dirset0,
-                pin0: &gpio.gpio.pin0,
-                set0: &gpio.gpio.set0,
-                clr0: &gpio.gpio.clr0,
+                dirset: slice::from_ref(&gpio.gpio.dirset0),
+                pin: slice::from_ref(&gpio.gpio.pin0),
+                set: slice::from_ref(&gpio.gpio.set0),
+                clr: slice::from_ref(&gpio.gpio.clr0),
 
                 _direction: gpio::direction::Unknown,
             },
             #[cfg(feature = "845")]
             state: pin_state::Gpio {
-                // TODO gpio1
-                dirset0: &gpio.gpio.dirset[0],
-                pin0: &gpio.gpio.pin[0],
-                set0: &gpio.gpio.set[0],
-                clr0: &gpio.gpio.clr[0],
+                dirset: &gpio.gpio.dirset,
+                pin: &gpio.gpio.pin,
+                set: &gpio.gpio.set,
+                clr: &gpio.gpio.clr,
 
                 _direction: gpio::direction::Unknown,
             },
@@ -723,9 +730,9 @@ pub mod pin_state {
 
     use crate::gpio::direction::Direction;
     #[cfg(feature = "845")]
-    use crate::raw_compat::gpio::{CLR as CLR0, DIRSET as DIRSET0, PIN as PIN0, SET as SET0};
+    use crate::raw_compat::gpio::{CLR, DIRSET, PIN, SET};
     #[cfg(feature = "82x")]
-    use crate::raw_compat::gpio::{CLR0, DIRSET0, PIN0, SET0};
+    use crate::raw_compat::gpio::{CLR0 as CLR, DIRSET0 as DIRSET, PIN0 as PIN, SET0 as SET};
 
     /// Implemented by types that indicate pin state
     ///
@@ -755,10 +762,10 @@ pub mod pin_state {
     ///
     /// [`Pin`]: ../struct.Pin.html
     pub struct Gpio<'gpio, D: Direction> {
-        pub(crate) dirset0: &'gpio DIRSET0,
-        pub(crate) pin0: &'gpio PIN0,
-        pub(crate) set0: &'gpio SET0,
-        pub(crate) clr0: &'gpio CLR0,
+        pub(crate) dirset: &'gpio [DIRSET],
+        pub(crate) pin: &'gpio [PIN],
+        pub(crate) set: &'gpio [SET],
+        pub(crate) clr: &'gpio [CLR],
 
         pub(crate) _direction: D,
     }
@@ -1101,29 +1108,28 @@ macro_rules! movable_functions {
             #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO0_29);
             #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO0_30);
             #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO0_31);
-            // TODO This is on gpio1
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_0 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_1 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_2 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_3 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_4 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_5 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_6 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_7 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_8 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_9 );
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_10);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_11);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_12);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_13);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_14);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_15);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_16);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_17);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_18);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_19);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_20);
-            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_21);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_0 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_1 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_2 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_3 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_4 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_5 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_6 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_7 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_8 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_9 );
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_10);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_11);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_12);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_13);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_14);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_15);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_16);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_17);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_18);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_19);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_20);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_21);
         )*
     }
 }
@@ -1140,9 +1146,9 @@ macro_rules! impl_function {
             type Kind = $kind;
 
             fn assign(&mut self, _pin: &mut $pin, swm: &mut Handle) {
-                swm.swm
-                    .$reg_name
-                    .modify(|_, w| unsafe { w.$reg_field().bits($pin::ID) });
+                swm.swm.$reg_name.modify(|_, w| unsafe {
+                    w.$reg_field().bits($pin::ID | ($pin::PORT as u8) << 5)
+                });
             }
 
             fn unassign(&mut self, _pin: &mut $pin, swm: &mut Handle) {
@@ -1387,17 +1393,16 @@ fixed_functions!(
     DACOUT0 , Analog, pinenable0, dacout0 , PIO0_17, state::Unassigned;
     DACOUT1 , Analog, pinenable0, dacout1 , PIO0_29, state::Unassigned;
     CAPT_X0 , Analog, pinenable0, capt_x0 , PIO0_31, state::Unassigned;
-    // TODO GPIO1
-    // CAPT_X1 , Analog, pinenable0, capt_x1 , PIO1_0 , state::Unassigned;
-    // CAPT_X2 , Analog, pinenable0, capt_x2 , PIO1_1 , state::Unassigned;
-    // CAPT_X3 , Analog, pinenable0, capt_x3 , PIO1_2 , state::Unassigned;
-    // CAPT_X4 , Analog, pinenable1, capt_x4 , PIO1_3 , state::Unassigned;
-    // CAPT_X5 , Analog, pinenable1, capt_x5 , PIO1_4 , state::Unassigned;
-    // CAPT_X6 , Analog, pinenable1, capt_x6 , PIO1_5 , state::Unassigned;
-    // CAPT_X7 , Analog, pinenable1, capt_x7 , PIO1_6 , state::Unassigned;
-    // CAPT_X8 , Analog, pinenable1, capt_x8 , PIO1_7 , state::Unassigned;
-    // CAPT_YL , Analog, pinenable1, capt_yl , PIO1_8 , state::Unassigned;
-    // CAPT_YH , Analog, pinenable1, capt_yh , PIO1_8 , state::Unassigned;
+    CAPT_X1 , Analog, pinenable0, capt_x1 , PIO1_0 , state::Unassigned;
+    CAPT_X2 , Analog, pinenable0, capt_x2 , PIO1_1 , state::Unassigned;
+    CAPT_X3 , Analog, pinenable0, capt_x3 , PIO1_2 , state::Unassigned;
+    CAPT_X4 , Analog, pinenable1, capt_x4 , PIO1_3 , state::Unassigned;
+    CAPT_X5 , Analog, pinenable1, capt_x5 , PIO1_4 , state::Unassigned;
+    CAPT_X6 , Analog, pinenable1, capt_x6 , PIO1_5 , state::Unassigned;
+    CAPT_X7 , Analog, pinenable1, capt_x7 , PIO1_6 , state::Unassigned;
+    CAPT_X8 , Analog, pinenable1, capt_x8 , PIO1_7 , state::Unassigned;
+    CAPT_YL , Analog, pinenable1, capt_yl , PIO1_8 , state::Unassigned;
+    CAPT_YH , Analog, pinenable1, capt_yh , PIO1_8 , state::Unassigned;
 );
 
 /// Contains types that indicate the state of fixed or movable functions

--- a/lpc8xx-hal-common/src/swm.rs
+++ b/lpc8xx-hal-common/src/swm.rs
@@ -1274,6 +1274,7 @@ macro_rules! fixed_functions {
     ($(
         $type:ident,
         $kind:ident,
+        $register:ident,
         $field:ident,
         $pin:ident,
         $default_state:ty;
@@ -1315,12 +1316,12 @@ macro_rules! fixed_functions {
 
 
                 fn assign(&mut self, _: &mut $pin, swm : &mut Handle) {
-                    swm.swm.pinenable0.modify(|_, w| w.$field().clear_bit());
+                    swm.swm.$register.modify(|_, w| w.$field().clear_bit());
                 }
 
                 fn unassign(&mut self, _: &mut $pin, swm : &mut Handle)
                 {
-                    swm.swm.pinenable0.modify(|_, w| w.$field().set_bit());
+                    swm.swm.$register.modify(|_, w| w.$field().set_bit());
                 }
             }
         )*
@@ -1329,75 +1330,74 @@ macro_rules! fixed_functions {
 
 #[cfg(feature = "82x")]
 fixed_functions!(
-    ACMP_I1 , Input , acmp_i1 , PIO0_0 , state::Unassigned;
-    ACMP_I2 , Input , acmp_i2 , PIO0_1 , state::Unassigned;
-    ACMP_I3 , Input , acmp_i3 , PIO0_14, state::Unassigned;
-    ACMP_I4 , Input , acmp_i4 , PIO0_23, state::Unassigned;
-    SWCLK   , Output, swclk   , PIO0_3 , state::Assigned<PIO0_3>;
-    SWDIO   , Output, swdio   , PIO0_2 , state::Assigned<PIO0_2>;
-    XTALIN  , Input , xtalin  , PIO0_8 , state::Unassigned;
-    XTALOUT , Output, xtalout , PIO0_9 , state::Unassigned;
-    RESETN  , Input , resetn  , PIO0_5 , state::Assigned<PIO0_5>;
-    CLKIN   , Input , clkin   , PIO0_1 , state::Unassigned;
-    VDDCMP  , Input , vddcmp  , PIO0_6 , state::Unassigned;
-    I2C0_SDA, Output, i2c0_sda, PIO0_11, state::Unassigned;
-    I2C0_SCL, Output, i2c0_scl, PIO0_10, state::Unassigned;
-    ADC_0   , Analog, adc_0   , PIO0_7 , state::Unassigned;
-    ADC_1   , Analog, adc_1   , PIO0_6 , state::Unassigned;
-    ADC_2   , Analog, adc_2   , PIO0_14, state::Unassigned;
-    ADC_3   , Analog, adc_3   , PIO0_23, state::Unassigned;
-    ADC_4   , Analog, adc_4   , PIO0_22, state::Unassigned;
-    ADC_5   , Analog, adc_5   , PIO0_21, state::Unassigned;
-    ADC_6   , Analog, adc_6   , PIO0_20, state::Unassigned;
-    ADC_7   , Analog, adc_7   , PIO0_19, state::Unassigned;
-    ADC_8   , Analog, adc_8   , PIO0_18, state::Unassigned;
-    ADC_9   , Analog, adc_9   , PIO0_17, state::Unassigned;
-    ADC_10  , Analog, adc_10  , PIO0_13, state::Unassigned;
-    ADC_11  , Analog, adc_11  , PIO0_4 , state::Unassigned;
+    ACMP_I1 , Input , pinenable0, acmp_i1 , PIO0_0 , state::Unassigned;
+    ACMP_I2 , Input , pinenable0, acmp_i2 , PIO0_1 , state::Unassigned;
+    ACMP_I3 , Input , pinenable0, acmp_i3 , PIO0_14, state::Unassigned;
+    ACMP_I4 , Input , pinenable0, acmp_i4 , PIO0_23, state::Unassigned;
+    SWCLK   , Output, pinenable0, swclk   , PIO0_3 , state::Assigned<PIO0_3>;
+    SWDIO   , Output, pinenable0, swdio   , PIO0_2 , state::Assigned<PIO0_2>;
+    XTALIN  , Input , pinenable0, xtalin  , PIO0_8 , state::Unassigned;
+    XTALOUT , Output, pinenable0, xtalout , PIO0_9 , state::Unassigned;
+    RESETN  , Input , pinenable0, resetn  , PIO0_5 , state::Assigned<PIO0_5>;
+    CLKIN   , Input , pinenable0, clkin   , PIO0_1 , state::Unassigned;
+    VDDCMP  , Input , pinenable0, vddcmp  , PIO0_6 , state::Unassigned;
+    I2C0_SDA, Output, pinenable0, i2c0_sda, PIO0_11, state::Unassigned;
+    I2C0_SCL, Output, pinenable0, i2c0_scl, PIO0_10, state::Unassigned;
+    ADC_0   , Analog, pinenable0, adc_0   , PIO0_7 , state::Unassigned;
+    ADC_1   , Analog, pinenable0, adc_1   , PIO0_6 , state::Unassigned;
+    ADC_2   , Analog, pinenable0, adc_2   , PIO0_14, state::Unassigned;
+    ADC_3   , Analog, pinenable0, adc_3   , PIO0_23, state::Unassigned;
+    ADC_4   , Analog, pinenable0, adc_4   , PIO0_22, state::Unassigned;
+    ADC_5   , Analog, pinenable0, adc_5   , PIO0_21, state::Unassigned;
+    ADC_6   , Analog, pinenable0, adc_6   , PIO0_20, state::Unassigned;
+    ADC_7   , Analog, pinenable0, adc_7   , PIO0_19, state::Unassigned;
+    ADC_8   , Analog, pinenable0, adc_8   , PIO0_18, state::Unassigned;
+    ADC_9   , Analog, pinenable0, adc_9   , PIO0_17, state::Unassigned;
+    ADC_10  , Analog, pinenable0, adc_10  , PIO0_13, state::Unassigned;
+    ADC_11  , Analog, pinenable0, adc_11  , PIO0_4 , state::Unassigned;
 );
 
 #[cfg(feature = "845")]
 fixed_functions!(
-    // pinenable0
-    ACMP_I1 , Input , acmp_i1 , PIO0_0 , state::Unassigned;
-    ACMP_I2 , Input , acmp_i2 , PIO0_1 , state::Unassigned;
-    ACMP_I3 , Input , acmp_i3 , PIO0_14, state::Unassigned;
-    ACMP_I4 , Input , acmp_i4 , PIO0_23, state::Unassigned;
-    SWCLK   , Output, swclk   , PIO0_3 , state::Assigned<PIO0_3>;
-    SWDIO   , Output, swdio   , PIO0_2 , state::Assigned<PIO0_2>;
-    XTALIN  , Input , xtalin  , PIO0_8 , state::Unassigned;
-    XTALOUT , Output, xtalout , PIO0_9 , state::Unassigned;
-    RESETN  , Input , resetn  , PIO0_5 , state::Assigned<PIO0_5>;
-    CLKIN   , Input , clkin   , PIO0_1 , state::Unassigned;
-    VDDCMP  , Input , vddcmp  , PIO0_6 , state::Unassigned;
-    I2C0_SDA, Output, i2c0_sda, PIO0_11, state::Unassigned;
-    I2C0_SCL, Output, i2c0_scl, PIO0_10, state::Unassigned;
-    ADC_0   , Analog, adc_0   , PIO0_7 , state::Unassigned;
-    ADC_1   , Analog, adc_1   , PIO0_6 , state::Unassigned;
-    ADC_2   , Analog, adc_2   , PIO0_14, state::Unassigned;
-    ADC_3   , Analog, adc_3   , PIO0_23, state::Unassigned;
-    ADC_4   , Analog, adc_4   , PIO0_22, state::Unassigned;
-    ADC_5   , Analog, adc_5   , PIO0_21, state::Unassigned;
-    ADC_6   , Analog, adc_6   , PIO0_20, state::Unassigned;
-    ADC_7   , Analog, adc_7   , PIO0_19, state::Unassigned;
-    ADC_8   , Analog, adc_8   , PIO0_18, state::Unassigned;
-    ADC_9   , Analog, adc_9   , PIO0_17, state::Unassigned;
-    ADC_10  , Analog, adc_10  , PIO0_13, state::Unassigned;
-    ADC_11  , Analog, adc_11  , PIO0_4 , state::Unassigned;
-    DACOUT0 , Analog, dacout0 , PIO0_17, state::Unassigned;
-    DACOUT1 , Analog, dacout1 , PIO0_29, state::Unassigned;
-    CAPT_X0 , Analog, capt_x0 , PIO0_31, state::Unassigned;
-    // CAPT_X1 , Analog, capt_x1 , PIO1_0 , state::Unassigned;
-    // CAPT_X2 , Analog, capt_x2 , PIO1_1 , state::Unassigned;
-    // CAPT_X3 , Analog, capt_x3 , PIO1_2 , state::Unassigned;
-    // TODO pinenable1
-    // CAPT_X4 , Analog, capt_x4 , PIO1_3 , state::Unassigned;
-    // CAPT_X5 , Analog, capt_x5 , PIO1_4 , state::Unassigned;
-    // CAPT_X6 , Analog, capt_x6 , PIO1_5 , state::Unassigned;
-    // CAPT_X7 , Analog, capt_x7 , PIO1_6 , state::Unassigned;
-    // CAPT_X8 , Analog, capt_x8 , PIO1_7 , state::Unassigned;
-    // CAPT_YL , Analog, capt_yl , PIO1_8 , state::Unassigned;
-    // CAPT_YH , Analog, capt_yh , PIO1_8 , state::Unassigned;
+    ACMP_I1 , Input , pinenable0, acmp_i1 , PIO0_0 , state::Unassigned;
+    ACMP_I2 , Input , pinenable0, acmp_i2 , PIO0_1 , state::Unassigned;
+    ACMP_I3 , Input , pinenable0, acmp_i3 , PIO0_14, state::Unassigned;
+    ACMP_I4 , Input , pinenable0, acmp_i4 , PIO0_23, state::Unassigned;
+    SWCLK   , Output, pinenable0, swclk   , PIO0_3 , state::Assigned<PIO0_3>;
+    SWDIO   , Output, pinenable0, swdio   , PIO0_2 , state::Assigned<PIO0_2>;
+    XTALIN  , Input , pinenable0, xtalin  , PIO0_8 , state::Unassigned;
+    XTALOUT , Output, pinenable0, xtalout , PIO0_9 , state::Unassigned;
+    RESETN  , Input , pinenable0, resetn  , PIO0_5 , state::Assigned<PIO0_5>;
+    CLKIN   , Input , pinenable0, clkin   , PIO0_1 , state::Unassigned;
+    VDDCMP  , Input , pinenable0, vddcmp  , PIO0_6 , state::Unassigned;
+    I2C0_SDA, Output, pinenable0, i2c0_sda, PIO0_11, state::Unassigned;
+    I2C0_SCL, Output, pinenable0, i2c0_scl, PIO0_10, state::Unassigned;
+    ADC_0   , Analog, pinenable0, adc_0   , PIO0_7 , state::Unassigned;
+    ADC_1   , Analog, pinenable0, adc_1   , PIO0_6 , state::Unassigned;
+    ADC_2   , Analog, pinenable0, adc_2   , PIO0_14, state::Unassigned;
+    ADC_3   , Analog, pinenable0, adc_3   , PIO0_23, state::Unassigned;
+    ADC_4   , Analog, pinenable0, adc_4   , PIO0_22, state::Unassigned;
+    ADC_5   , Analog, pinenable0, adc_5   , PIO0_21, state::Unassigned;
+    ADC_6   , Analog, pinenable0, adc_6   , PIO0_20, state::Unassigned;
+    ADC_7   , Analog, pinenable0, adc_7   , PIO0_19, state::Unassigned;
+    ADC_8   , Analog, pinenable0, adc_8   , PIO0_18, state::Unassigned;
+    ADC_9   , Analog, pinenable0, adc_9   , PIO0_17, state::Unassigned;
+    ADC_10  , Analog, pinenable0, adc_10  , PIO0_13, state::Unassigned;
+    ADC_11  , Analog, pinenable0, adc_11  , PIO0_4 , state::Unassigned;
+    DACOUT0 , Analog, pinenable0, dacout0 , PIO0_17, state::Unassigned;
+    DACOUT1 , Analog, pinenable0, dacout1 , PIO0_29, state::Unassigned;
+    CAPT_X0 , Analog, pinenable0, capt_x0 , PIO0_31, state::Unassigned;
+    // TODO GPIO1
+    // CAPT_X1 , Analog, pinenable0, capt_x1 , PIO1_0 , state::Unassigned;
+    // CAPT_X2 , Analog, pinenable0, capt_x2 , PIO1_1 , state::Unassigned;
+    // CAPT_X3 , Analog, pinenable0, capt_x3 , PIO1_2 , state::Unassigned;
+    // CAPT_X4 , Analog, pinenable1, capt_x4 , PIO1_3 , state::Unassigned;
+    // CAPT_X5 , Analog, pinenable1, capt_x5 , PIO1_4 , state::Unassigned;
+    // CAPT_X6 , Analog, pinenable1, capt_x6 , PIO1_5 , state::Unassigned;
+    // CAPT_X7 , Analog, pinenable1, capt_x7 , PIO1_6 , state::Unassigned;
+    // CAPT_X8 , Analog, pinenable1, capt_x8 , PIO1_7 , state::Unassigned;
+    // CAPT_YL , Analog, pinenable1, capt_yl , PIO1_8 , state::Unassigned;
+    // CAPT_YH , Analog, pinenable1, capt_yh , PIO1_8 , state::Unassigned;
 );
 
 /// Contains types that indicate the state of fixed or movable functions

--- a/lpc8xx-hal-common/src/swm.rs
+++ b/lpc8xx-hal-common/src/swm.rs
@@ -234,6 +234,7 @@ macro_rules! pins {
     }
 }
 
+#[cfg(feature = "82x")]
 pins!(
     pio0_0 , PIO0_0 , 0x00, pin_state::Unused        , pin_state::Unused;
     pio0_1 , PIO0_1 , 0x01, pin_state::Unused        , pin_state::Unused;
@@ -264,6 +265,65 @@ pins!(
     pio0_26, PIO0_26, 0x1a, pin_state::Unused        , pin_state::Unused;
     pio0_27, PIO0_27, 0x1b, pin_state::Unused        , pin_state::Unused;
     pio0_28, PIO0_28, 0x1c, pin_state::Unused        , pin_state::Unused;
+);
+
+#[cfg(feature = "845")]
+pins!(
+    pio0_0 , PIO0_0 , 0x00, pin_state::Unused        , pin_state::Unused;
+    pio0_1 , PIO0_1 , 0x01, pin_state::Unused        , pin_state::Unused;
+    pio0_2 , PIO0_2 , 0x02, pin_state::Swm<((),), ()>, pin_state::Swm::new();
+    pio0_3 , PIO0_3 , 0x03, pin_state::Swm<((),), ()>, pin_state::Swm::new();
+    pio0_4 , PIO0_4 , 0x04, pin_state::Unused        , pin_state::Unused;
+    pio0_5 , PIO0_5 , 0x05, pin_state::Swm<(), ((),)>, pin_state::Swm::new();
+    pio0_6 , PIO0_6 , 0x06, pin_state::Unused        , pin_state::Unused;
+    pio0_7 , PIO0_7 , 0x07, pin_state::Unused        , pin_state::Unused;
+    pio0_8 , PIO0_8 , 0x08, pin_state::Unused        , pin_state::Unused;
+    pio0_9 , PIO0_9 , 0x09, pin_state::Unused        , pin_state::Unused;
+    pio0_10, PIO0_10, 0x0a, pin_state::Unused        , pin_state::Unused;
+    pio0_11, PIO0_11, 0x0b, pin_state::Unused        , pin_state::Unused;
+    pio0_12, PIO0_12, 0x0c, pin_state::Unused        , pin_state::Unused;
+    pio0_13, PIO0_13, 0x0d, pin_state::Unused        , pin_state::Unused;
+    pio0_14, PIO0_14, 0x0e, pin_state::Unused        , pin_state::Unused;
+    pio0_15, PIO0_15, 0x0f, pin_state::Unused        , pin_state::Unused;
+    pio0_16, PIO0_16, 0x10, pin_state::Unused        , pin_state::Unused;
+    pio0_17, PIO0_17, 0x11, pin_state::Unused        , pin_state::Unused;
+    pio0_18, PIO0_18, 0x12, pin_state::Unused        , pin_state::Unused;
+    pio0_19, PIO0_19, 0x13, pin_state::Unused        , pin_state::Unused;
+    pio0_20, PIO0_20, 0x14, pin_state::Unused        , pin_state::Unused;
+    pio0_21, PIO0_21, 0x15, pin_state::Unused        , pin_state::Unused;
+    pio0_22, PIO0_22, 0x16, pin_state::Unused        , pin_state::Unused;
+    pio0_23, PIO0_23, 0x17, pin_state::Unused        , pin_state::Unused;
+    pio0_24, PIO0_24, 0x18, pin_state::Unused        , pin_state::Unused;
+    pio0_25, PIO0_25, 0x19, pin_state::Unused        , pin_state::Unused;
+    pio0_26, PIO0_26, 0x1a, pin_state::Unused        , pin_state::Unused;
+    pio0_27, PIO0_27, 0x1b, pin_state::Unused        , pin_state::Unused;
+    pio0_28, PIO0_28, 0x1c, pin_state::Unused        , pin_state::Unused;
+    pio0_29, PIO0_29, 0x1d, pin_state::Unused        , pin_state::Unused;
+    pio0_30, PIO0_30, 0x1e, pin_state::Unused        , pin_state::Unused;
+    pio0_31, PIO0_31, 0x1f, pin_state::Unused        , pin_state::Unused;
+    // TODO this is on gpio1
+    // pio1_0 , PIO1_0 , 0x00, pin_state::Unused        , pin_state::Unused;
+    // pio1_1 , PIO1_1 , 0x01, pin_state::Unused        , pin_state::Unused;
+    // pio1_2 , PIO1_2 , 0x02, pin_state::Unusetd       , pin_state::Unused;
+    // pio1_3 , PIO1_3 , 0x03, pin_state::Unusetd       , pin_state::Unused;
+    // pio1_4 , PIO1_4 , 0x04, pin_state::Unused        , pin_state::Unused;
+    // pio1_5 , PIO1_5 , 0x05, pin_state::Unusetd       , pin_state::Unused;
+    // pio1_6 , PIO1_6 , 0x06, pin_state::Unused        , pin_state::Unused;
+    // pio1_7 , PIO1_7 , 0x07, pin_state::Unused        , pin_state::Unused;
+    // pio1_8 , PIO1_8 , 0x08, pin_state::Unused        , pin_state::Unused;
+    // pio1_9 , PIO1_9 , 0x09, pin_state::Unused        , pin_state::Unused;
+    // pio1_10, PIO1_10, 0x0a, pin_state::Unused        , pin_state::Unused;
+    // pio1_11, PIO1_11, 0x0b, pin_state::Unused        , pin_state::Unused;
+    // pio1_12, PIO1_12, 0x0c, pin_state::Unused        , pin_state::Unused;
+    // pio1_13, PIO1_13, 0x0d, pin_state::Unused        , pin_state::Unused;
+    // pio1_14, PIO1_14, 0x0e, pin_state::Unused        , pin_state::Unused;
+    // pio1_15, PIO1_15, 0x0f, pin_state::Unused        , pin_state::Unused;
+    // pio1_16, PIO1_16, 0x10, pin_state::Unused        , pin_state::Unused;
+    // pio1_17, PIO1_17, 0x11, pin_state::Unused        , pin_state::Unused;
+    // pio1_18, PIO1_18, 0x12, pin_state::Unused        , pin_state::Unused;
+    // pio1_19, PIO1_19, 0x13, pin_state::Unused        , pin_state::Unused;
+    // pio1_20, PIO1_20, 0x14, pin_state::Unused        , pin_state::Unused;
+    // pio1_21, PIO1_21, 0x15, pin_state::Unused        , pin_state::Unused;
 );
 
 /// Main API to control for controlling pins
@@ -1038,6 +1098,32 @@ macro_rules! movable_functions {
             impl_function!($type, $kind, $reg_name, $reg_field, PIO0_26);
             impl_function!($type, $kind, $reg_name, $reg_field, PIO0_27);
             impl_function!($type, $kind, $reg_name, $reg_field, PIO0_28);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO0_29);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO0_30);
+            #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO0_31);
+            // TODO This is on gpio1
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_0 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_1 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_2 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_3 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_4 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_5 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_6 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_7 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_8 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_9 );
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_10);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_11);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_12);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_13);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_14);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_15);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_16);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_17);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_18);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_19);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_20);
+            // #[cfg(feature = "845")] impl_function!($type, $kind, $reg_name, $reg_field, PIO1_21);
         )*
     }
 }
@@ -1068,6 +1154,7 @@ macro_rules! impl_function {
     };
 }
 
+#[cfg(feature = "82x")]
 movable_functions!(
     u0_txd       , U0_TXD       , Output, pinassign0 , u0_txd_o;
     u0_rxd       , U0_RXD       , Input , pinassign0 , u0_rxd_i;
@@ -1117,6 +1204,70 @@ movable_functions!(
     acmp_o       , ACMP_O       , Output, pinassign11, acmp_o_o;
     clkout       , CLKOUT       , Output, pinassign11, clkout_o;
     gpio_int_bmat, GPIO_INT_BMAT, Output, pinassign11, gpio_int_bmat_o;
+);
+
+#[cfg(feature = "845")]
+movable_functions!(
+    u0_txd       , U0_TXD       , Output, pinassign0 , u0_txd_o;
+    u0_rxd       , U0_RXD       , Input , pinassign0 , u0_rxd_i;
+    u0_rts       , U0_RTS       , Output, pinassign0 , u0_rts_o;
+    u0_cts       , U0_CTS       , Input , pinassign0 , u0_cts_i;
+    u0_sclk      , U0_SCLK      , Output, pinassign1 , u0_sclk_io;
+    u1_txd       , U1_TXD       , Output, pinassign1 , u1_txd_o;
+    u1_rxd       , U1_RXD       , Input , pinassign1 , u1_rxd_i;
+    u1_rts       , U1_RTS       , Output, pinassign1 , u1_rts_o;
+    u1_cts       , U1_CTS       , Input , pinassign2 , u1_cts_i;
+    u1_sclk      , U1_SCLK      , Output, pinassign2 , u1_sclk_io;
+    u2_txd       , U2_TXD       , Output, pinassign2 , u2_txd_o;
+    u2_rxd       , U2_RXD       , Input , pinassign2 , u2_rxd_i;
+    u2_rts       , U2_RTS       , Output, pinassign3 , u2_rts_o;
+    u2_cts       , U2_CTS       , Input , pinassign3 , u2_cts_i;
+    u2_sclk      , U2_SCLK      , Output, pinassign3 , u2_sclk_io;
+    spi0_sck     , SPI0_SCK     , Output, pinassign3 , spi0_sck_io;
+    spi0_mosi    , SPI0_MOSI    , Output, pinassign4 , spi0_mosi_io;
+    spi0_miso    , SPI0_MISO    , Output, pinassign4 , spi0_miso_io;
+    spi0_ssel0   , SPI0_SSEL0   , Output, pinassign4 , spi0_ssel0_io;
+    spi0_ssel1   , SPI0_SSEL1   , Output, pinassign4 , spi0_ssel1_io;
+    spi0_ssel2   , SPI0_SSEL2   , Output, pinassign5 , spi0_ssel2_io;
+    spi0_ssel3   , SPI0_SSEL3   , Output, pinassign5 , spi0_ssel3_io;
+    spi1_sck     , SPI1_SCK     , Output, pinassign5 , spi1_sck_io;
+    spi1_mosi    , SPI1_MOSI    , Output, pinassign5 , spi1_mosi_io;
+    spi1_miso    , SPI1_MISO    , Output, pinassign6 , spi1_miso_io;
+    spi1_ssel0   , SPI1_SSEL0   , Output, pinassign6 , spi1_ssel0_io;
+    spi1_ssel1   , SPI1_SSEL1   , Output, pinassign6 , spi1_ssel1_io;
+    sct_pin0     , SCT_PIN0     , Input , pinassign6 , sct0_gpio_in_a_i;
+    sct_pin1     , SCT_PIN1     , Input , pinassign7 , sct0_gpio_in_b_i;
+    sct_pin2     , SCT_PIN2     , Input , pinassign7 , sct0_gpio_in_c_i;
+    sct_pin3     , SCT_PIN3     , Input , pinassign7 , sct0_gpio_in_d_i;
+    sct_out0     , SCT_OUT0     , Output, pinassign7 , sct_out0_o;
+    sct_out1     , SCT_OUT1     , Output, pinassign8 , sct_out1_o;
+    sct_out2     , SCT_OUT2     , Output, pinassign8 , sct_out2_o;
+    sct_out3     , SCT_OUT3     , Output, pinassign8 , sct_out3_o;
+    sct_out4     , SCT_OUT4     , Output, pinassign8 , sct_out4_o;
+    sct_out5     , SCT_OUT5     , Output, pinassign9 , sct_out5_o;
+    sct_out6     , SCT_OUT6     , Output, pinassign9 , sct_out6_o;
+    i2c1_sda     , I2C1_SDA     , Output, pinassign9 , i2c1_sda_io;
+    i2c1_scl     , I2C1_SCL     , Output, pinassign9 , i2c1_scl_io;
+    i2c2_sda     , I2C2_SDA     , Output, pinassign10, i2c2_sda_io;
+    i2c2_scl     , I2C2_SCL     , Output, pinassign10, i2c2_scl_io;
+    i2c3_sda     , I2C3_SDA     , Output, pinassign10, i2c3_sda_io;
+    i2c3_scl     , I2C3_SCL     , Output, pinassign10, i2c3_scl_io;
+    acmp_o       , ACMP_O       , Output, pinassign11, comp0_out_o;
+    clkout       , CLKOUT       , Output, pinassign11, clkout_o;
+    gpio_int_bmat, GPIO_INT_BMAT, Output, pinassign11, gpio_int_bmat_o;
+    uart3_txd    , UART3_TXD    , Output, pinassign11, uart3_txd;
+    uart3_rxd    , UART3_RXD    , Input , pinassign12, uart3_rxd;
+    uart3_sclk   , UART3_SCLK   , Output, pinassign12, uart3_sclk;
+    uart4_txd    , UART4_TXD    , Output, pinassign12, uart4_txd;
+    uart4_rxd    , UART4_RXD    , Input , pinassign12, uart4_rxd;
+    uart4_sclk   , UART4_SCLK   , Output, pinassign13, uart4_sclk;
+    t0_mat0      , T0_MAT0      , Output, pinassign13, t0_mat0;
+    t0_mat1      , T0_MAT1      , Output, pinassign13, t0_mat1;
+    t0_mat2      , T0_MAT2      , Output, pinassign13, t0_mat2;
+    t0_mat3      , T0_MAT3      , Output, pinassign14, t0_mat3;
+    t0_cap0      , T0_CAP0      , Output, pinassign14, t0_cap0;
+    t0_cap1      , T0_CAP1      , Output, pinassign14, t0_cap1;
+    t0_cap2      , T0_CAP2      , Output, pinassign14, t0_cap2;
 );
 
 macro_rules! fixed_functions {
@@ -1176,6 +1327,7 @@ macro_rules! fixed_functions {
     }
 }
 
+#[cfg(feature = "82x")]
 fixed_functions!(
     ACMP_I1 , Input , acmp_i1 , PIO0_0 , state::Unassigned;
     ACMP_I2 , Input , acmp_i2 , PIO0_1 , state::Unassigned;
@@ -1202,6 +1354,51 @@ fixed_functions!(
     ADC_9   , Adc   , adc_9   , PIO0_17, state::Unassigned;
     ADC_10  , Adc   , adc_10  , PIO0_13, state::Unassigned;
     ADC_11  , Adc   , adc_11  , PIO0_4 , state::Unassigned;
+);
+
+#[cfg(feature = "845")]
+fixed_functions!(
+    // pinenable0
+    ACMP_I1 , Input , acmp_i1 , PIO0_0 , state::Unassigned;
+    ACMP_I2 , Input , acmp_i2 , PIO0_1 , state::Unassigned;
+    ACMP_I3 , Input , acmp_i3 , PIO0_14, state::Unassigned;
+    ACMP_I4 , Input , acmp_i4 , PIO0_23, state::Unassigned;
+    SWCLK   , Output, swclk   , PIO0_3 , state::Assigned<PIO0_3>;
+    SWDIO   , Output, swdio   , PIO0_2 , state::Assigned<PIO0_2>;
+    XTALIN  , Input , xtalin  , PIO0_8 , state::Unassigned;
+    XTALOUT , Output, xtalout , PIO0_9 , state::Unassigned;
+    RESETN  , Input , resetn  , PIO0_5 , state::Assigned<PIO0_5>;
+    CLKIN   , Input , clkin   , PIO0_1 , state::Unassigned;
+    VDDCMP  , Input , vddcmp  , PIO0_6 , state::Unassigned;
+    I2C0_SDA, Output, i2c0_sda, PIO0_11, state::Unassigned;
+    I2C0_SCL, Output, i2c0_scl, PIO0_10, state::Unassigned;
+    ADC_0   , Adc   , adc_0   , PIO0_7 , state::Unassigned;
+    ADC_1   , Adc   , adc_1   , PIO0_6 , state::Unassigned;
+    ADC_2   , Adc   , adc_2   , PIO0_14, state::Unassigned;
+    ADC_3   , Adc   , adc_3   , PIO0_23, state::Unassigned;
+    ADC_4   , Adc   , adc_4   , PIO0_22, state::Unassigned;
+    ADC_5   , Adc   , adc_5   , PIO0_21, state::Unassigned;
+    ADC_6   , Adc   , adc_6   , PIO0_20, state::Unassigned;
+    ADC_7   , Adc   , adc_7   , PIO0_19, state::Unassigned;
+    ADC_8   , Adc   , adc_8   , PIO0_18, state::Unassigned;
+    ADC_9   , Adc   , adc_9   , PIO0_17, state::Unassigned;
+    ADC_10  , Adc   , adc_10  , PIO0_13, state::Unassigned;
+    ADC_11  , Adc   , adc_11  , PIO0_4 , state::Unassigned;
+    DACOUT0 , Adc   , dacout0 , PIO0_17, state::Unassigned;
+    DACOUT1 , Adc   , dacout1 , PIO0_29, state::Unassigned;
+    // TODO Is it input or output?
+    CAPT_X0 , Adc   , capt_x0 , PIO0_31, state::Unassigned;
+    // CAPT_X1 , Adc   , capt_x1 , PIO1_0 , state::Unassigned;
+    // CAPT_X2 , Adc   , capt_x2 , PIO1_1 , state::Unassigned;
+    // CAPT_X3 , Adc   , capt_x3 , PIO1_2 , state::Unassigned;
+    // pinenable1
+    // CAPT_X4 , Adc   , capt_x4 , PIO1_3 , state::Unassigned;
+    // CAPT_X5 , Adc   , capt_x5 , PIO1_4 , state::Unassigned;
+    // CAPT_X6 , Adc   , capt_x6 , PIO1_5 , state::Unassigned;
+    // CAPT_X7 , Adc   , capt_x7 , PIO1_6 , state::Unassigned;
+    // CAPT_X8 , Adc   , capt_x8 , PIO1_7 , state::Unassigned;
+    // CAPT_YL , Adc   , capt_yl , PIO1_8 , state::Unassigned;
+    // CAPT_YH , Adc   , capt_yh , PIO1_8 , state::Unassigned;
 );
 
 /// Contains types that indicate the state of fixed or movable functions

--- a/lpc8xx-hal-common/src/syscon.rs
+++ b/lpc8xx-hal-common/src/syscon.rs
@@ -387,8 +387,6 @@ impl_clock_control!(FLASH, flash);
 impl_clock_control!(raw::I2C0, i2c0);
 #[cfg(feature = "82x")]
 impl_clock_control!(raw_compat::GPIO, gpio);
-#[cfg(feature = "845")]
-impl_clock_control!(raw_compat::GPIO, gpio0);
 impl_clock_control!(raw_compat::SWM0, swm);
 impl_clock_control!(raw_compat::SCT0, sct);
 impl_clock_control!(raw::WKT, wkt);
@@ -408,6 +406,16 @@ impl_clock_control!(raw::I2C3, i2c3);
 impl_clock_control!(raw_compat::ADC0, adc);
 impl_clock_control!(MTB, mtb);
 impl_clock_control!(raw_compat::DMA0, dma);
+#[cfg(feature = "845")]
+impl ClockControl for raw_compat::GPIO {
+    fn enable_clock<'w>(&self, w: &'w mut sysahbclkctrl::W) -> &'w mut sysahbclkctrl::W {
+        w.gpio0().enable().gpio1().enable()
+    }
+
+    fn disable_clock<'w>(&self, w: &'w mut sysahbclkctrl::W) -> &'w mut sysahbclkctrl::W {
+        w.gpio0().disable().gpio1().disable()
+    }
+}
 
 /// Internal trait for controlling peripheral reset
 ///
@@ -455,9 +463,6 @@ impl_reset_control!(raw_compat::SCT0, sct_rst_n);
 impl_reset_control!(raw::WKT, wkt_rst_n);
 #[cfg(feature = "82x")]
 impl_reset_control!(raw_compat::GPIO, gpio_rst_n);
-#[cfg(feature = "845")]
-// TODO gpio1
-impl_reset_control!(raw_compat::GPIO, gpio0_rst_n);
 impl_reset_control!(raw_compat::FLASH_CTRL, flash_rst_n);
 impl_reset_control!(raw_compat::ACOMP, acmp_rst_n);
 impl_reset_control!(raw::I2C1, i2c1_rst_n);
@@ -465,6 +470,17 @@ impl_reset_control!(raw::I2C2, i2c2_rst_n);
 impl_reset_control!(raw::I2C3, i2c3_rst_n);
 impl_reset_control!(raw_compat::ADC0, adc_rst_n);
 impl_reset_control!(raw_compat::DMA0, dma_rst_n);
+
+#[cfg(feature = "845")]
+impl<'a> ResetControl for raw_compat::GPIO {
+    fn assert_reset<'w>(&self, w: &'w mut presetctrl::W) -> &'w mut presetctrl::W {
+        w.gpio0_rst_n().clear_bit().gpio1_rst_n().clear_bit()
+    }
+
+    fn clear_reset<'w>(&self, w: &'w mut presetctrl::W) -> &'w mut presetctrl::W {
+        w.gpio0_rst_n().set_bit().gpio1_rst_n().set_bit()
+    }
+}
 
 /// Internal trait for powering analog blocks
 ///


### PR DESCRIPTION
 - Add compatibility layer for differently named peripherals `raw_compat` (Unfortunately couldn't find a way to do the same for registers)
- Add pin assignments for for lpc845
  - Currently a few are commented out, as gpio1 & pinenable1 are currently missing 
  - There's now also a Dac & capacitive measurement, I think the best way to handle them is to rename `pin_state::Adc` to `pin_state::Analog`.
- Disable UARTFRG & IRC for lpc845, as they don't exist
- Add `Peripherals` to lpc845. As the gpio is per default disabled, this also meant adding an additional `new` constructor(?) for disabled gpio peripherals and renaming the old one to `new_enabled`.
- Add a gpio example. Currently without accurate timing, as that isn't ported yet

As an aside: What's your policy about rom routines, as the fro (internal oscillator) of the lpc845 doesn't seem to be configurable otherwise
