### PR TITLE
LPC845 fixup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ name              = "gpio"
 required-features = ["rt", "82x"]
 
 [[example]]
+name              = "845_gpio"
+required-features = ["rt", "845"]
+
+[[example]]
 name              = "i2c_vl53l0x"
 required-features = ["rt", "82x"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,8 @@ default = ["82x"]
 # This is needed to make the compiletest stuff optional. It requires std, which
 # means we can't build it together with the examples.
 compiletest = ["compiletest_rs"]
-rt          = ["cortex-m-rt", "lpc82x-pac/rt", "lpc845-pac/rt"]
+rt          = ["cortex-m-rt", "lpc82x-pac/rt"]
+rt_845      = ["cortex-m-rt", "lpc845-pac/rt"]
 
 
 [[example]]
@@ -65,7 +66,7 @@ required-features = ["rt", "82x"]
 
 [[example]]
 name              = "845_gpio"
-required-features = ["rt", "845"]
+required-features = ["rt_845", "845"]
 
 [[example]]
 name              = "i2c_vl53l0x"

--- a/examples/845_gpio.rs
+++ b/examples/845_gpio.rs
@@ -33,9 +33,11 @@ fn main() -> ! {
         // For this simple demo accurate timing isn't required and this is the
         // simplest Method to delay
         for _ in 0..1000000 {
+            #[allow(deprecated)]
             pio1_1.set_high();
         }
         for _ in 0..1000000 {
+            #[allow(deprecated)]
             pio1_1.set_low();
         }
     }

--- a/examples/845_gpio.rs
+++ b/examples/845_gpio.rs
@@ -1,0 +1,42 @@
+#![no_main]
+#![no_std]
+
+#[allow(unused_imports)]
+use panic_halt;
+
+use lpc8xx_hal::prelude::*;
+use lpc8xx_hal::Peripherals;
+
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    // Get access to the device's peripherals. Since only one instance of this
+    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // If we tried to call the method a second time, it would return `None`, but
+    // we're only calling it the one time here, so we can safely `unwrap` the
+    // `Option` without causing a panic.
+    let p = Peripherals::take().unwrap();
+
+    // Initialize the APIs of the peripherals we need.
+    let swm = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
+    // let mut wkt = p.WKT.enable(&mut syscon.handle);
+    let gpio = p.GPIO.enable(&mut syscon.handle);
+
+    // Configure the PIO1_1 pin. The API tracks the state of pins at
+    // compile-time, to prevent any mistakes.
+    let mut pio1_1 = swm.pins.pio1_1.into_gpio_pin(&gpio).into_output();
+
+    // Blink the LED
+    loop {
+        // For this simple demo accurate timing isn't required and this is the
+        // simplest Method to delay
+        for _ in 0..1000000 {
+            pio1_1.set_high();
+        }
+        for _ in 0..1000000 {
+            pio1_1.set_low();
+        }
+    }
+}

--- a/openocd_lpc845.cfg
+++ b/openocd_lpc845.cfg
@@ -1,0 +1,14 @@
+source [find interface/cmsis-dap.cfg]
+
+transport select swd
+set WORKAREASIZE 8096
+
+source [find target/lpc84x.cfg]
+
+adapter_khz 1000
+
+gdb_port pipe
+log_output openocd.log
+
+init
+halt

--- a/openocd_lpc845.gdb
+++ b/openocd_lpc845.gdb
@@ -1,0 +1,3 @@
+target remote | openocd -f openocd_lpc845.cfg
+load
+continue

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,4 +5,4 @@ set -e
 export RUSTFLAGS="-D warnings"
 
 cargo build --verbose --no-default-features --features=rt,82x --examples
-cargo build --verbose --no-default-features --features=rt,845 --examples
+cargo build --verbose --no-default-features --features=rt_845,845 --examples


### PR DESCRIPTION
This:
- (Re-)adds the lpc845 gpio example
- Add correct openocd config

TODO:
`rt` feature doesn't work. Both pac crates seem to added as dependencies, with the lpc82x-pac `device.x` being used on my machine, regardless of the selected mcu. This results in linker failure. 

The simplest fix appears to be adding two separate `rt` features, but that might result in user confusion