### PR TITLE
Add delay implementation based on systick

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,10 @@ name              = "gpio_simple"
 required-features = ["rt-selected"]
 
 [[example]]
+name              = "gpio_delay"
+required-features = ["rt-selected"]
+
+[[example]]
 name              = "i2c_vl53l0x"
 required-features = ["rt-selected", "82x"]
 

--- a/examples/gpio_delay.rs
+++ b/examples/gpio_delay.rs
@@ -1,0 +1,47 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use lpc8xx_hal::{cortex_m_rt::entry, prelude::*, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    // Get access to the device's peripherals. Since only one instance of this
+    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // If we tried to call the method a second time, it would return `None`, but
+    // we're only calling it the one time here, so we can safely `unwrap` the
+    // `Option` without causing a panic.
+    let p = Peripherals::take().unwrap();
+
+    // Initialize the APIs of the peripherals we need.
+    let swm = p.SWM.split();
+    let mut delay = p.SYST.enable_delay();
+    #[cfg(feature = "82x")]
+    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    #[cfg(feature = "845")]
+    let gpio = {
+        let mut syscon = p.SYSCON.split();
+        p.GPIO.enable(&mut syscon.handle)
+    };
+
+    // Select pin for LED
+    #[cfg(feature = "82x")]
+    let led = swm.pins.pio0_12;
+    #[cfg(feature = "845")]
+    let led = swm.pins.pio1_1;
+
+    // Configure the LED pin. The API tracks the state of pins at compile time,
+    // to prevent any mistakes.
+    let mut led = led.into_gpio_pin(&gpio).into_output();
+
+    // Blink the LED using the systick with the delay traits
+    loop {
+        delay.delay_ms(1_000_u16);
+        #[allow(deprecated)]
+        led.set_high();
+        delay.delay_ms(1_000_u16);
+        #[allow(deprecated)]
+        led.set_low();
+    }
+}

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,0 +1,118 @@
+//! API for delays with the systick timer
+//!
+//! Please be aware of potential overflows when using `delay_us`.
+//! E.g. at 30MHz the maximum delay is 146 seconds.
+//!
+//! # Example
+//!
+//! ``` no_run
+//! use lpc82x_hal::prelude::*;
+//! use lpc82x_hal::Peripherals;
+//!
+//! let mut p = Peripherals::take().unwrap();
+//!
+//! let mut delay = p.SYST.enable_delay();
+//! loop {
+//!     delay.delay_ms(1_000_u16);
+//! }
+//! ```
+
+use cortex_m::peripheral::syst::SystClkSource;
+
+use crate::raw::SYST;
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
+
+/// System timer (SysTick) as a delay provider
+#[derive(Clone)]
+pub struct Delay {
+    scale: u32,
+}
+
+const SYSTICK_RANGE: u32 = 0x0100_0000;
+const SYSTEM_CLOCK: u32 = 12_000_000;
+/// Helper trait to add methods to `SYST`
+pub trait SystDelay {
+    /// Turn the Systick into a delay istance
+    fn enable_delay(self) -> Delay;
+}
+impl SystDelay for SYST {
+    /// Configures the system timer (SysTick) as a delay provider
+    fn enable_delay(mut self) -> Delay {
+        assert!(SYSTEM_CLOCK >= 1_000_000);
+        let scale = SYSTEM_CLOCK / 1_000_000;
+        self.set_clock_source(SystClkSource::Core);
+
+        self.set_reload(SYSTICK_RANGE - 1);
+        self.clear_current();
+        self.enable_counter();
+
+        Delay { scale }
+        // As access to the count register is possible without a reference to the systick, we can
+        // safely clone the enabled instance.
+    }
+}
+
+impl DelayMs<u32> for Delay {
+    // At 30 MHz (the maximum frequency), calling delay_us with ms * 1_000 directly overflows at 0x418937 (over the max u16 value)
+    // So we implement a separate, higher level, delay loop
+    fn delay_ms(&mut self, mut ms: u32) {
+        const MAX_MS: u32 = 0x0000_FFFF;
+        while ms != 0 {
+            let current_ms = if ms <= MAX_MS { ms } else { MAX_MS };
+            self.delay_us(current_ms * 1_000);
+            ms -= current_ms;
+        }
+    }
+}
+
+impl DelayMs<u16> for Delay {
+    fn delay_ms(&mut self, ms: u16) {
+        // Call delay_us directly, since we don't have to use the additional
+        // delay loop the u32 variant uses
+        self.delay_us(ms as u32 * 1_000);
+    }
+}
+
+impl DelayMs<u8> for Delay {
+    fn delay_ms(&mut self, ms: u8) {
+        self.delay_ms(ms as u16);
+    }
+}
+
+// At 30MHz (the maximum frequency), this overflows at approx. 2^32 / 30 = 146 seconds
+impl DelayUs<u32> for Delay {
+    fn delay_us(&mut self, us: u32) {
+        // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
+        // Here half the maximum is used so we have some play if there's a long running interrupt.
+        const MAX_TICKS: u32 = 0x007F_FFFF;
+
+        let mut total_ticks = us * self.scale;
+
+        while total_ticks != 0 {
+            let current_ticks = if total_ticks <= MAX_TICKS {
+                total_ticks
+            } else {
+                MAX_TICKS
+            };
+
+            let start_count = SYST::get_current();
+            total_ticks -= current_ticks;
+
+            // Use the wrapping substraction and the modulo to deal with the systick wrapping around
+            // from 0 to 0xFFFF
+            while (start_count.wrapping_sub(SYST::get_current()) % SYSTICK_RANGE) < current_ticks {}
+        }
+    }
+}
+
+impl DelayUs<u16> for Delay {
+    fn delay_us(&mut self, us: u16) {
+        self.delay_us(us as u32)
+    }
+}
+
+impl DelayUs<u8> for Delay {
+    fn delay_us(&mut self, us: u8) {
+        self.delay_us(us as u32)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub extern crate nb;
 pub(crate) mod reg_proxy;
 
 pub mod clock;
+pub mod delay;
 #[cfg(feature = "82x")]
 pub mod dma;
 #[cfg(feature = "82x")]
@@ -141,6 +142,7 @@ pub mod prelude {
         Enabled as _lpc82x_hal_clock_Enabled, Frequency as _lpc82x_hal_clock_Frequency,
     };
     pub use crate::hal::prelude::*;
+    pub use crate::delay::SystDelay;
     #[cfg(feature = "82x")]
     pub use crate::sleep::Sleep as _;
 }


### PR DESCRIPTION
This is based on https://github.com/stm32-rs/stm32f0xx-hal/blob/master/src/delay.rs, (mostly) written by myself and adjusted to better fit the api.

Also adds a gpio example based on this that's less hacky for the lpc845.

I didn't find a way to get the current system frequency & (for example) i2c seems to rely on it being 12 MHz, so it's just hardcoded for now.