### PR TITLE
Add debug information to release builds & more optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,11 @@ required-features = ["rt-selected", "82x"]
 [[example]]
 name              = "usart"
 required-features = ["rt-selected", "82x"]
+
+[profile.dev]
+debug = true
+
+[profile.release]
+debug = true
+lto = true
+opt-level = "s"


### PR DESCRIPTION
Otherwise debugging in release mode doesn't provide the corresponding source code in gdb.

Also optimizes more, so that the release build is as small as possible