### PR TITLE
Enable WKT for lpc845

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ compiletest = ["compiletest_rs"]
 
 [[example]]
 name              = "gpio_sleep"
-required-features = ["rt-selected", "82x"]
+required-features = ["rt-selected"]
 
 [[example]]
 name              = "gpio_simple"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,15 +113,12 @@ pub mod dma;
 #[cfg(feature = "82x")]
 pub mod i2c;
 pub mod gpio;
-#[cfg(feature = "82x")]
 pub mod pmu;
-#[cfg(feature = "82x")]
 pub mod sleep;
 pub mod swm;
 pub mod syscon;
 #[cfg(feature = "82x")]
 pub mod usart;
-#[cfg(feature = "82x")]
 pub mod wkt;
 
 
@@ -145,7 +142,6 @@ pub mod prelude {
         prelude::*,
         digital::v2::*,
     };
-    #[cfg(feature = "82x")]
     pub use crate::sleep::Sleep as _;
 }
 
@@ -160,13 +156,11 @@ pub use self::dma::DMA;
 pub use self::gpio::GPIO;
 #[cfg(feature = "82x")]
 pub use self::i2c::I2C;
-#[cfg(feature = "82x")]
 pub use self::pmu::PMU;
 pub use self::swm::SWM;
 pub use self::syscon::SYSCON;
 #[cfg(feature = "82x")]
 pub use self::usart::USART;
-#[cfg(feature = "82x")]
 pub use self::wkt::WKT;
 
 
@@ -558,11 +552,7 @@ pub struct Peripherals {
     pub SYSCON: SYSCON,
 
     /// Self-wake-up timer (WKT)
-    ///
-    /// A HAL API for this peripheral has not been implemented yet. In the
-    /// meantime, this field provides you with the raw register mappings, which
-    /// allow you full, unprotected access to the peripheral.
-    pub WKT: pac::WKT,
+    pub WKT: WKT<init_state::Disabled>,
 
     /// Analog comparator
     ///
@@ -684,11 +674,7 @@ pub struct Peripherals {
     pub PINT: pac::PINT,
 
     /// Power Management Unit
-    ///
-    /// A HAL API for this peripheral has not been implemented yet. In the
-    /// meantime, this field provides you with the raw register mappings, which
-    /// allow you full, unprotected access to the peripheral.
-    pub PMU: pac::PMU,
+    pub PMU: PMU,
 
     /// State Configurable Timer (SCT)
     ///
@@ -877,8 +863,10 @@ impl Peripherals {
             // NOTE(unsafe) The init state of the gpio peripheral is enabled,
             // thus it's safe to create an already initialized gpio port
             GPIO: GPIO::new(p.GPIO),
+            PMU   : PMU::new(p.PMU),
             SWM: SWM::new(p.SWM0),
             SYSCON: SYSCON::new(p.SYSCON),
+            WKT   : WKT::new(p.WKT),
 
             // Raw peripherals
             ACOMP: p.ACOMP,
@@ -898,7 +886,6 @@ impl Peripherals {
             IOCON: p.IOCON,
             MRT0: p.MRT0,
             PINT: p.PINT,
-            PMU: p.PMU,
             SCT0: p.SCT0,
             SPI0: p.SPI0,
             SPI1: p.SPI1,
@@ -907,7 +894,6 @@ impl Peripherals {
             USART2: p.USART2,
             USART3: p.USART3,
             USART4: p.USART4,
-            WKT: p.WKT,
             WWDT: p.WWDT,
 
             // Core peripherals

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -36,6 +36,10 @@ use embedded_hal::timer;
 use nb;
 use void::Void;
 
+#[cfg(feature = "845")]
+use crate::syscon::FroDerivedClock;
+#[cfg(feature = "82x")]
+use crate::syscon::IrcDerivedClock;
 use crate::{
     init_state,
     pac::{
@@ -43,12 +47,8 @@ use crate::{
         wkt::ctrl,
     },
     pmu::LowPowerClock,
-    syscon::{
-        self,
-        IrcDerivedClock,
-    },
+    syscon::self,
 };
-
 
 /// Interface to the self-wake-up timer (WKT)
 ///
@@ -198,8 +198,19 @@ pub trait Clock {
     fn select<'w>(w: &'w mut ctrl::W) -> &'w mut ctrl::W;
 }
 
+#[cfg(feature = "82x")]
 impl<State> Clock for IrcDerivedClock<State> {
     fn select<'w>(w: &'w mut ctrl::W) -> &'w mut ctrl::W {
+        w
+            .sel_extclk().internal()
+            .clksel().divided_irc_clock()
+    }
+}
+
+#[cfg(feature = "845")]
+impl<State> Clock for FroDerivedClock<State> {
+    fn select<'w>(w: &'w mut ctrl::W) -> &'w mut ctrl::W {
+        // TODO svd bug, wrong value name
         w
             .sel_extclk().internal()
             .clksel().divided_irc_clock()


### PR DESCRIPTION
FroDerivedClock is the only thing different, but it's the same as IrcDerivedClock with a different name (no idea why nxp did that).