### PR TITLE
Fix panic in build script, if target doesn't exist

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,7 @@
-use std::{fs::File, io::prelude::*};
+use std::{
+    fs::{self, File},
+    io::prelude::*,
+};
 
 use termion::{color, style};
 
@@ -17,6 +20,8 @@ fn main() {
             );
         }
     };
+
+    fs::create_dir_all("target").expect("Failed to create target directory");
 
     File::create("target/openocd.cfg")
         .expect("Failed to create openocd.cfg")

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,11 @@ fn main() {
         }
     };
 
+    // These file operations are not using the `OUT_DIR` environment variable on
+    // purpose. `OUT_DIR` points to a directory within target, whose path even
+    // contains a hash. This configuration file needs to be referenced from the
+    // GDB configuration, which can't just ask Cargo where to look for it.
+
     fs::create_dir_all("target").expect("Failed to create target directory");
 
     File::create("target/openocd.cfg")


### PR DESCRIPTION
I ran into this when starting a new project depending on LPC8xx HAL.
Seems pretty serious, since this might be the first point of contact
with this library for many users.