### PR TITLE
Set maximum line width to 80

### DIFF
--- a/examples/gpio_sleep.rs
+++ b/examples/gpio_sleep.rs
@@ -3,7 +3,9 @@
 
 extern crate panic_halt;
 
-use lpc8xx_hal::{clock::Ticks, cortex_m_rt::entry, prelude::*, sleep, Peripherals};
+use lpc8xx_hal::{
+    clock::Ticks, cortex_m_rt::entry, prelude::*, sleep, Peripherals,
+};
 
 #[entry]
 fn main() -> ! {

--- a/examples/i2c_vl53l0x.rs
+++ b/examples/i2c_vl53l0x.rs
@@ -16,7 +16,8 @@ extern crate panic_halt;
 use core::fmt::Write;
 
 use lpc8xx_hal::{
-    cortex_m_rt::entry, prelude::*, syscon::clocksource::PeripheralClockConfig, Peripherals,
+    cortex_m_rt::entry, prelude::*, syscon::clocksource::PeripheralClockConfig,
+    Peripherals,
 };
 
 #[entry]

--- a/examples/pmu.rs
+++ b/examples/pmu.rs
@@ -38,9 +38,9 @@ fn main() -> ! {
         .u0_txd
         .assign(swm.pins.pio0_4.into_swm_pin(), &mut swm.handle);
 
-    let serial = p
-        .USART0
-        .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
+    let serial =
+        p.USART0
+            .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
 
     let _ = pmu.low_power_clock.enable(&mut pmu.handle);
 

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -4,7 +4,8 @@
 extern crate panic_halt;
 
 use lpc8xx_hal::{
-    cortex_m_rt::entry, prelude::*, syscon::clocksource::PeripheralClockConfig, Peripherals,
+    cortex_m_rt::entry, prelude::*, syscon::clocksource::PeripheralClockConfig,
+    Peripherals,
 };
 
 #[cfg(feature = "845")]
@@ -98,13 +99,15 @@ fn main() -> ! {
     // LPC845-BRK development boards, they're connected to the integrated USB to
     // Serial converter. So by using the pins, we can use them to communicate
     // with a host PC, without additional hardware.
-    let (u0_rxd, _) = swm.movable_functions.u0_rxd.assign(rx_pin, &mut swm.handle);
-    let (u0_txd, _) = swm.movable_functions.u0_txd.assign(tx_pin, &mut swm.handle);
+    let (u0_rxd, _) =
+        swm.movable_functions.u0_rxd.assign(rx_pin, &mut swm.handle);
+    let (u0_txd, _) =
+        swm.movable_functions.u0_txd.assign(tx_pin, &mut swm.handle);
 
     // Enable USART0
-    let serial = p
-        .USART0
-        .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
+    let serial =
+        p.USART0
+            .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
 
     // Send a string via USART0, blocking until it has been sent
     serial

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -96,7 +96,10 @@ impl DelayUs<u32> for Delay {
 
             // Use the wrapping substraction and the modulo to deal with the systick wrapping around
             // from 0 to 0xFFFF
-            while (start_count.wrapping_sub(SYST::get_current()) % SYSTICK_RANGE) < current_ticks {}
+            while (start_count.wrapping_sub(SYST::get_current())
+                % SYSTICK_RANGE)
+                < current_ticks
+            {}
         }
     }
 }

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -94,7 +94,10 @@ impl Handle<init_state::Disabled> {
 
 impl<'dma> Handle<init_state::Disabled> {
     /// Enable the DMA controller
-    pub fn enable(self, syscon: &mut syscon::Handle) -> Handle<init_state::Enabled> {
+    pub fn enable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> Handle<init_state::Enabled> {
         syscon.enable_clock(&self.dma);
 
         // Set descriptor table address
@@ -119,7 +122,10 @@ impl<'dma> Handle<init_state::Disabled> {
 
 impl Handle<init_state::Enabled> {
     /// Disable the DMA controller
-    pub fn disable(self, syscon: &mut syscon::Handle) -> Handle<init_state::Disabled> {
+    pub fn disable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> Handle<init_state::Disabled> {
         syscon.disable_clock(&self.dma);
 
         Handle {
@@ -212,7 +218,10 @@ where
     T: ChannelTrait,
 {
     /// Enable the channel
-    pub fn enable<'dma>(self, dma: &'dma Handle) -> Channel<T, init_state::Enabled<&'dma Handle>> {
+    pub fn enable<'dma>(
+        self,
+        dma: &'dma Handle,
+    ) -> Channel<T, init_state::Enabled<&'dma Handle>> {
         Channel {
             ty: self.ty,
             _state: init_state::Enabled(dma),
@@ -237,7 +246,11 @@ where
     /// # Limitations
     ///
     /// The length of `source` must be 1024 or less.
-    pub fn start_transfer<D>(self, source: &'static mut [u8], mut dest: D) -> Transfer<'dma, T, D>
+    pub fn start_transfer<D>(
+        self,
+        source: &'static mut [u8],
+        mut dest: D,
+    ) -> Transfer<'dma, T, D>
     where
         D: Dest,
     {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -98,7 +98,10 @@ impl GPIO<init_state::Disabled> {
     ///
     /// [`Disabled`]: ../init_state/struct.Disabled.html
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub fn enable(self, syscon: &mut syscon::Handle) -> GPIO<init_state::Enabled> {
+    pub fn enable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> GPIO<init_state::Enabled> {
         syscon.enable_clock(&self.gpio);
 
         GPIO {
@@ -120,7 +123,10 @@ impl GPIO<init_state::Enabled> {
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
     /// [`Disabled`]: ../init_state/struct.Disabled.html
-    pub fn disable(self, syscon: &mut syscon::Handle) -> GPIO<init_state::Disabled> {
+    pub fn disable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> GPIO<init_state::Disabled> {
         syscon.disable_clock(&self.gpio);
 
         GPIO {
@@ -181,8 +187,11 @@ where
     /// pin.set_high();
     /// pin.set_low();
     /// ```
-    pub fn into_output(self) -> Pin<T, pin_state::Gpio<'gpio, direction::Output>> {
-        self.state.dirset[T::PORT].write(|w| unsafe { w.dirsetp().bits(T::MASK) });
+    pub fn into_output(
+        self,
+    ) -> Pin<T, pin_state::Gpio<'gpio, direction::Output>> {
+        self.state.dirset[T::PORT]
+            .write(|w| unsafe { w.dirsetp().bits(T::MASK) });
 
         Pin {
             ty: self.ty,
@@ -238,7 +247,8 @@ where
     }
 }
 
-impl<'gpio, T> StatefulOutputPin for Pin<T, pin_state::Gpio<'gpio, direction::Output>>
+impl<'gpio, T> StatefulOutputPin
+    for Pin<T, pin_state::Gpio<'gpio, direction::Output>>
 where
     T: PinTrait,
 {

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -194,7 +194,11 @@ impl i2c::Read for I2C<init_state::Enabled> {
     /// Reading multiple bytes should work, but has not been tested.
     ///
     /// [embedded-hal documentation]: https://docs.rs/embedded-hal/0.2.1/embedded_hal/blocking/i2c/trait.Read.html#tymethod.read
-    fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+    fn read(
+        &mut self,
+        address: u8,
+        buffer: &mut [u8],
+    ) -> Result<(), Self::Error> {
         // Wait until peripheral is idle
         while !self.i2c.stat.read().mststate().is_idle() {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,8 @@ pub mod wkt;
 /// imports.
 pub mod prelude {
     pub use crate::clock::{
-        Enabled as _lpc82x_hal_clock_Enabled, Frequency as _lpc82x_hal_clock_Frequency,
+        Enabled as _lpc82x_hal_clock_Enabled,
+        Frequency as _lpc82x_hal_clock_Frequency,
     };
     pub use crate::hal::{digital::v2::*, prelude::*};
     pub use crate::sleep::Sleep as _;

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -241,7 +241,10 @@ impl LowPowerClock<init_state::Disabled> {
     /// [`Disabled`]: ../init_state/struct.Disabled.html
     /// [`Enabled`]: ../init_state/struct.Enabled.html
     /// [`clock::Enabled`]: ../clock/trait.Enabled.html
-    pub fn enable(self, pmu: &mut Handle) -> LowPowerClock<init_state::Enabled> {
+    pub fn enable(
+        self,
+        pmu: &mut Handle,
+    ) -> LowPowerClock<init_state::Enabled> {
         pmu.pmu.dpdctrl.modify(|_, w| w.lposcen().enabled());
 
         LowPowerClock {
@@ -262,7 +265,10 @@ impl LowPowerClock<init_state::Enabled> {
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
     /// [`Disabled`]: ../init_state/struct.Disabled.html
-    pub fn disable(self, pmu: &mut Handle) -> LowPowerClock<init_state::Disabled> {
+    pub fn disable(
+        self,
+        pmu: &mut Handle,
+    ) -> LowPowerClock<init_state::Disabled> {
         pmu.pmu.dpdctrl.modify(|_, w| w.lposcen().disabled());
 
         LowPowerClock {

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -161,7 +161,11 @@ impl<'r> Regular<'r> {
     /// Requires references to various peripherals, which will be borrowed for
     /// as long as the `sleep::Regular` instance exists, as they will be needed
     /// for every call to [`Sleep::sleep`].
-    pub fn prepare(pmu: &'r mut pmu::Handle, scb: &'r mut pac::SCB, wkt: &'r mut WKT) -> Self {
+    pub fn prepare(
+        pmu: &'r mut pmu::Handle,
+        scb: &'r mut pac::SCB,
+        wkt: &'r mut WKT,
+    ) -> Self {
         Regular { pmu, scb, wkt }
     }
 }

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -126,7 +126,10 @@ impl Handle<init_state::Disabled> {
     ///
     /// [`Disabled`]: ../init_state/struct.Disabled.html
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub fn enable(self, syscon: &mut syscon::Handle) -> Handle<init_state::Enabled> {
+    pub fn enable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> Handle<init_state::Enabled> {
         syscon.enable_clock(&self.swm);
 
         Handle {
@@ -148,7 +151,10 @@ impl Handle<init_state::Enabled> {
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
     /// [`Disabled`]: ../init_state/struct.Disabled.html
-    pub fn disable(self, syscon: &mut syscon::Handle) -> Handle<init_state::Disabled> {
+    pub fn disable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> Handle<init_state::Disabled> {
         syscon.disable_clock(&self.swm);
 
         Handle {
@@ -557,7 +563,10 @@ where
     /// ```
     ///
     /// [State Management]: #state-management
-    pub fn into_gpio_pin(self, gpio: &GPIO) -> Pin<T, pin_state::Gpio<gpio::direction::Unknown>> {
+    pub fn into_gpio_pin(
+        self,
+        gpio: &GPIO,
+    ) -> Pin<T, pin_state::Gpio<gpio::direction::Unknown>> {
         // Isn't used for lpc845
         #[allow(unused_imports)]
         use core::slice;
@@ -677,7 +686,8 @@ where
     }
 }
 
-impl<T, F, O, Is> UnassignFunction<F, Input> for Pin<T, pin_state::Swm<O, (Is,)>>
+impl<T, F, O, Is> UnassignFunction<F, Input>
+    for Pin<T, pin_state::Swm<O, (Is,)>>
 where
     T: PinTrait,
     F: FunctionTrait<T, Kind = Input>,
@@ -732,7 +742,9 @@ pub mod pin_state {
     #[cfg(feature = "845")]
     use crate::pac::gpio::{CLR, DIRSET, PIN, SET};
     #[cfg(feature = "82x")]
-    use crate::pac::gpio::{CLR0 as CLR, DIRSET0 as DIRSET, PIN0 as PIN, SET0 as SET};
+    use crate::pac::gpio::{
+        CLR0 as CLR, DIRSET0 as DIRSET, PIN0 as PIN, SET0 as SET,
+    };
 
     /// Implemented by types that indicate pin state
     ///

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -30,15 +30,16 @@ use core::marker::PhantomData;
 
 #[cfg(feature = "82x")]
 use crate::pac::syscon::{
-    pdruncfg, presetctrl as presetctrl0, starterp1, sysahbclkctrl as sysahbclkctrl0, PDRUNCFG,
-    PRESETCTRL as PRESETCTRL0, STARTERP1, SYSAHBCLKCTRL as SYSAHBCLKCTRL0, UARTCLKDIV, UARTFRGDIV,
+    pdruncfg, presetctrl as presetctrl0, starterp1,
+    sysahbclkctrl as sysahbclkctrl0, PDRUNCFG, PRESETCTRL as PRESETCTRL0,
+    STARTERP1, SYSAHBCLKCTRL as SYSAHBCLKCTRL0, UARTCLKDIV, UARTFRGDIV,
     UARTFRGMULT,
 };
 
 #[cfg(feature = "845")]
 use crate::pac::syscon::{
-    pdruncfg, presetctrl0, starterp1, sysahbclkctrl0, FCLKSEL, PDRUNCFG, PRESETCTRL0, STARTERP1,
-    SYSAHBCLKCTRL0,
+    pdruncfg, presetctrl0, starterp1, sysahbclkctrl0, FCLKSEL, PDRUNCFG,
+    PRESETCTRL0, STARTERP1, SYSAHBCLKCTRL0,
 };
 
 use crate::{clock, init_state, pac, reg_proxy::RegProxy};
@@ -386,20 +387,32 @@ impl UARTFRG {
 /// [`syscon::Handle::disable_clock`]: struct.Handle.html#method.disable_clock
 pub trait ClockControl {
     /// Internal method to enable a peripheral clock
-    fn enable_clock<'w>(&self, w: &'w mut sysahbclkctrl0::W) -> &'w mut sysahbclkctrl0::W;
+    fn enable_clock<'w>(
+        &self,
+        w: &'w mut sysahbclkctrl0::W,
+    ) -> &'w mut sysahbclkctrl0::W;
 
     /// Internal method to disable a peripheral clock
-    fn disable_clock<'w>(&self, w: &'w mut sysahbclkctrl0::W) -> &'w mut sysahbclkctrl0::W;
+    fn disable_clock<'w>(
+        &self,
+        w: &'w mut sysahbclkctrl0::W,
+    ) -> &'w mut sysahbclkctrl0::W;
 }
 
 macro_rules! impl_clock_control {
     ($clock_control:ty, $clock:ident) => {
         impl ClockControl for $clock_control {
-            fn enable_clock<'w>(&self, w: &'w mut sysahbclkctrl0::W) -> &'w mut sysahbclkctrl0::W {
+            fn enable_clock<'w>(
+                &self,
+                w: &'w mut sysahbclkctrl0::W,
+            ) -> &'w mut sysahbclkctrl0::W {
                 w.$clock().set_bit()
             }
 
-            fn disable_clock<'w>(&self, w: &'w mut sysahbclkctrl0::W) -> &'w mut sysahbclkctrl0::W {
+            fn disable_clock<'w>(
+                &self,
+                w: &'w mut sysahbclkctrl0::W,
+            ) -> &'w mut sysahbclkctrl0::W {
                 w.$clock().clear_bit()
             }
         }
@@ -441,11 +454,17 @@ impl_clock_control!(MTB, mtb);
 impl_clock_control!(pac::DMA0, dma);
 #[cfg(feature = "845")]
 impl ClockControl for pac::GPIO {
-    fn enable_clock<'w>(&self, w: &'w mut sysahbclkctrl0::W) -> &'w mut sysahbclkctrl0::W {
+    fn enable_clock<'w>(
+        &self,
+        w: &'w mut sysahbclkctrl0::W,
+    ) -> &'w mut sysahbclkctrl0::W {
         w.gpio0().enable().gpio1().enable()
     }
 
-    fn disable_clock<'w>(&self, w: &'w mut sysahbclkctrl0::W) -> &'w mut sysahbclkctrl0::W {
+    fn disable_clock<'w>(
+        &self,
+        w: &'w mut sysahbclkctrl0::W,
+    ) -> &'w mut sysahbclkctrl0::W {
         w.gpio0().disable().gpio1().disable()
     }
 }
@@ -463,20 +482,32 @@ impl ClockControl for pac::GPIO {
 /// [`syscon::Handle::clear_reset`]: struct.Handle.html#method.clear_reset
 pub trait ResetControl {
     /// Internal method to assert peripheral reset
-    fn assert_reset<'w>(&self, w: &'w mut presetctrl0::W) -> &'w mut presetctrl0::W;
+    fn assert_reset<'w>(
+        &self,
+        w: &'w mut presetctrl0::W,
+    ) -> &'w mut presetctrl0::W;
 
     /// Internal method to clear peripheral reset
-    fn clear_reset<'w>(&self, w: &'w mut presetctrl0::W) -> &'w mut presetctrl0::W;
+    fn clear_reset<'w>(
+        &self,
+        w: &'w mut presetctrl0::W,
+    ) -> &'w mut presetctrl0::W;
 }
 
 macro_rules! impl_reset_control {
     ($reset_control:ty, $field:ident) => {
         impl<'a> ResetControl for $reset_control {
-            fn assert_reset<'w>(&self, w: &'w mut presetctrl0::W) -> &'w mut presetctrl0::W {
+            fn assert_reset<'w>(
+                &self,
+                w: &'w mut presetctrl0::W,
+            ) -> &'w mut presetctrl0::W {
                 w.$field().clear_bit()
             }
 
-            fn clear_reset<'w>(&self, w: &'w mut presetctrl0::W) -> &'w mut presetctrl0::W {
+            fn clear_reset<'w>(
+                &self,
+                w: &'w mut presetctrl0::W,
+            ) -> &'w mut presetctrl0::W {
                 w.$field().set_bit()
             }
         }
@@ -510,12 +541,18 @@ impl_reset_control!(pac::DMA0, dma_rst_n);
 
 #[cfg(feature = "845")]
 impl<'a> ResetControl for pac::GPIO {
-    fn assert_reset<'w>(&self, w: &'w mut presetctrl0::W) -> &'w mut presetctrl0::W {
+    fn assert_reset<'w>(
+        &self,
+        w: &'w mut presetctrl0::W,
+    ) -> &'w mut presetctrl0::W {
         w.gpio0_rst_n().clear_bit();
         w.gpio1_rst_n().clear_bit()
     }
 
-    fn clear_reset<'w>(&self, w: &'w mut presetctrl0::W) -> &'w mut presetctrl0::W {
+    fn clear_reset<'w>(
+        &self,
+        w: &'w mut presetctrl0::W,
+    ) -> &'w mut presetctrl0::W {
         w.gpio0_rst_n().set_bit();
         w.gpio1_rst_n().set_bit()
     }
@@ -543,11 +580,17 @@ pub trait AnalogBlock {
 macro_rules! impl_analog_block {
     ($analog_block:ty, $field:ident) => {
         impl<'a> AnalogBlock for $analog_block {
-            fn power_up<'w>(&self, w: &'w mut pdruncfg::W) -> &'w mut pdruncfg::W {
+            fn power_up<'w>(
+                &self,
+                w: &'w mut pdruncfg::W,
+            ) -> &'w mut pdruncfg::W {
                 w.$field().clear_bit()
             }
 
-            fn power_down<'w>(&self, w: &'w mut pdruncfg::W) -> &'w mut pdruncfg::W {
+            fn power_down<'w>(
+                &self,
+                w: &'w mut pdruncfg::W,
+            ) -> &'w mut pdruncfg::W {
                 w.$field().set_bit()
             }
         }

--- a/src/syscon/clocksource_82x.rs
+++ b/src/syscon/clocksource_82x.rs
@@ -21,7 +21,9 @@ impl<USART: crate::usart::Peripheral> PeripheralClockConfig<USART> {
     }
 }
 
-impl<USART: crate::usart::Peripheral> PeripheralClock<USART> for PeripheralClockConfig<USART> {
+impl<USART: crate::usart::Peripheral> PeripheralClock<USART>
+    for PeripheralClockConfig<USART>
+{
     fn select_clock(&self, _: &mut syscon::Handle) {
         // NOOP, selected by default
     }

--- a/src/syscon/clocksource_845.rs
+++ b/src/syscon/clocksource_845.rs
@@ -79,11 +79,12 @@ impl PeripheralClockSource for IOSC {
     const CLOCK: SEL_A = SEL_A::FRO;
 }
 
-impl<PERIPH: PeripheralClockSelector, CLOCK: PeripheralClockSource> PeripheralClock<PERIPH>
-    for PeripheralClockConfig<PERIPH, CLOCK>
+impl<PERIPH: PeripheralClockSelector, CLOCK: PeripheralClockSource>
+    PeripheralClock<PERIPH> for PeripheralClockConfig<PERIPH, CLOCK>
 {
     fn select_clock(&self, syscon: &mut syscon::Handle) {
-        syscon.fclksel[PERIPH::REGISTER_NUM].write(|w| w.sel().variant(CLOCK::CLOCK));
+        syscon.fclksel[PERIPH::REGISTER_NUM]
+            .write(|w| w.sel().variant(CLOCK::CLOCK));
     }
     fn get_psc(&self) -> u16 {
         self.psc

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -188,7 +188,10 @@ where
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
     /// [`Disabled`]: ../init_state/struct.Disabled.html
-    pub fn disable(self, syscon: &mut syscon::Handle) -> USART<UsartX, init_state::Disabled> {
+    pub fn disable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> USART<UsartX, init_state::Disabled> {
         syscon.disable_clock(&self.usart);
 
         USART {
@@ -395,7 +398,9 @@ where
 /// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
 /// be considered breaking changes.
 pub trait Peripheral:
-    Deref<Target = pac::usart0::RegisterBlock> + syscon::ClockControl + syscon::ResetControl
+    Deref<Target = pac::usart0::RegisterBlock>
+    + syscon::ClockControl
+    + syscon::ResetControl
 {
     /// The interrupt that is triggered for this USART peripheral
     const INTERRUPT: Interrupt;

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -75,7 +75,10 @@ impl WKT<init_state::Disabled> {
     ///
     /// [`Disabled`]: ../init_state/struct.Disabled.html
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub fn enable(self, syscon: &mut syscon::Handle) -> WKT<init_state::Enabled> {
+    pub fn enable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> WKT<init_state::Enabled> {
         syscon.enable_clock(&self.wkt);
 
         WKT {
@@ -97,7 +100,10 @@ impl WKT<init_state::Enabled> {
     ///
     /// [`Enabled`]: ../init_state/struct.Enabled.html
     /// [`Disabled`]: ../init_state/struct.Disabled.html
-    pub fn disable(self, syscon: &mut syscon::Handle) -> WKT<init_state::Disabled> {
+    pub fn disable(
+        self,
+        syscon: &mut syscon::Handle,
+    ) -> WKT<init_state::Disabled> {
         syscon.disable_clock(&self.wkt);
 
         WKT {


### PR DESCRIPTION
Before we introduced `cargo fmt`, I kept my line widths to 80, but the default for `cargo fmt` is 100. I guess which one is better is mostly subjective, but given the size of my screen, the way I divide it between different applications, and my preferred font size, 100 is just too long :-)

So yeah, I prefer this setting. Please let me know what you think.