### PR TITLE
Force swm to be enabled on lpc845, fix #183

### DIFF
--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -15,17 +15,13 @@ use lpc8xx_hal::pac::syscon::frg::frgclksel::SEL_A;
 fn main() -> ! {
     let p = Peripherals::take().unwrap();
 
-    let mut swm = p.SWM.split();
+    let swm = p.SWM.split();
     let mut syscon = p.SYSCON.split();
 
-    // TODO
-    //
-    // For some reason, the clock for swm need to be enabled, even though
-    // it should be enabled from the start
-    swm.handle = swm
-        .handle
-        .disable(&mut syscon.handle)
-        .enable(&mut syscon.handle);
+    #[cfg(feature = "82x")]
+    let mut handle = swm.handle;
+    #[cfg(feature = "845")]
+    let mut handle = swm.handle.enable(&mut syscon.handle); // SWM isn't enabled by default on LPC845.
 
     #[cfg(feature = "82x")]
     // Set baud rate to 115200 baud
@@ -99,10 +95,8 @@ fn main() -> ! {
     // LPC845-BRK development boards, they're connected to the integrated USB to
     // Serial converter. So by using the pins, we can use them to communicate
     // with a host PC, without additional hardware.
-    let (u0_rxd, _) =
-        swm.movable_functions.u0_rxd.assign(rx_pin, &mut swm.handle);
-    let (u0_txd, _) =
-        swm.movable_functions.u0_txd.assign(tx_pin, &mut swm.handle);
+    let (u0_rxd, _) = swm.movable_functions.u0_rxd.assign(rx_pin, &mut handle);
+    let (u0_txd, _) = swm.movable_functions.u0_txd.assign(tx_pin, &mut handle);
 
     // Enable USART0
     let serial =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,24 @@ pub struct Peripherals {
     pub PMU: PMU,
 
     /// Switch matrix
-    pub SWM: SWM,
+    ///
+    /// By default, the switch matrix is enabled on the LPC82x and disabled on
+    /// the LPC845.
+    ///
+    /// The reference manual for the LPC845 suggests otherwise, but it seems to
+    /// be wrong.
+    #[cfg(feature = "82x")]
+    pub SWM: SWM<init_state::Enabled>,
+
+    /// Switch matrix
+    ///
+    /// By default, the switch matrix is enabled on the LPC82x and disabled on
+    /// the LPC845.
+    ///
+    /// The reference manual for the LPC845 suggests otherwise, but it seems to
+    /// be wrong.
+    #[cfg(feature = "845")]
+    pub SWM: SWM<init_state::Disabled>,
 
     /// System configuration
     pub SYSCON: SYSCON,
@@ -512,7 +529,10 @@ impl Peripherals {
             #[cfg(feature = "82x")]
             I2C0: I2C::new(p.I2C0),
             PMU: PMU::new(p.PMU),
-            SWM: SWM::new(p.SWM0),
+            #[cfg(feature = "82x")]
+            SWM: unsafe { SWM::new_enabled(p.SWM0) },
+            #[cfg(feature = "845")]
+            SWM: unsafe { SWM::new(p.SWM0) },
             SYSCON: SYSCON::new(p.SYSCON),
             USART0: USART::new(p.USART0),
             USART1: USART::new(p.USART1),


### PR DESCRIPTION
Also makes the `new` functions public, to stay in line with gpio and
bypass unused function warnings.

Was there a good reason to implement these on `Handle` instead of the whole peripheral?