### PR TITLE
Re-export clock source enum from `frg` module

### DIFF
--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -9,7 +9,7 @@ use lpc8xx_hal::{
 };
 
 #[cfg(feature = "845")]
-use lpc8xx_hal::pac::syscon::frg::frgclksel::SEL_A;
+use lpc8xx_hal::syscon::frg;
 
 #[entry]
 fn main() -> ! {
@@ -64,7 +64,7 @@ fn main() -> ! {
     // case), and we get our division by 6 by setting the BRGVAL of the
     // USART instance (setting its value to 5 means division by 6).
     let clock_config = {
-        syscon.frg0.select_clock(SEL_A::FRO);
+        syscon.frg0.select_clock(frg::Clock::FRO);
         syscon.frg0.set_mult(22);
         syscon.frg0.set_div(0xFF);
         PeripheralClockConfig::new(&syscon.frg0, 5)

--- a/src/syscon/frg.rs
+++ b/src/syscon/frg.rs
@@ -3,10 +3,15 @@
 use crate::{
     pac::{
         self,
-        syscon::frg::{frgclksel::SEL_A, FRGCLKSEL, FRGDIV, FRGMULT},
+        syscon::frg::{FRGCLKSEL, FRGDIV, FRGMULT},
     },
     reg_proxy::{Reg, RegProxy},
 };
+
+/// Clock sources for the FRG
+///
+/// Can be passed to [`FRG::select_clock`].
+pub use crate::pac::syscon::frg::frgclksel::SEL_A as Clock;
 
 /// Fractional generator
 ///
@@ -30,7 +35,7 @@ where
     }
 
     /// Select clock source for FRG
-    pub fn select_clock(&mut self, clock: SEL_A) {
+    pub fn select_clock(&mut self, clock: Clock) {
         self.clksel.write(|w| w.sel().variant(clock));
     }
 


### PR DESCRIPTION
This makes the API much friendlier, as it no longer requires the user to
import an obscure type from the PAC.