### PR TITLE
Fix out of date documentation

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -27,7 +27,7 @@
 //! Please refer to the [examples in the repository] for more example code.
 //!
 //! [`swm`]: ../swm/index.html
-//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/lpc82x-hal/examples
+//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/examples
 
 use embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
 use void::Void;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -42,7 +42,7 @@
 //!
 //! Please refer to the [examples in the repository] for more example code.
 //!
-//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/lpc82x-hal/examples
+//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/examples
 
 use embedded_hal::blocking::i2c;
 use void::Void;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! Again, the available options are listed in [`Cargo.toml`].
 //!
-//! Please note that LPC82x HAL is an implementation of [embedded-hal]. If you
+//! Please note that LPC8xx HAL is an implementation of [embedded-hal]. If you
 //! are writing code that is not specific to LPC800, please consider depending
 //! on embedded-hal instead.
 //!
@@ -90,12 +90,8 @@
 //! manual, which is [available from NXP].
 //!
 //! [embedded-hal]: https://crates.io/crates/embedded-hal
-//! [cortex-m-quickstart]: https://github.com/japaric/cortex-m-quickstart
-//! [cortex-m-rt]: https://crates.io/crates/cortex-m-rt
-//! [rustup]: https://rustup.rs/
-//! [This fork of lpc21isp]: https://github.com/hannobraun/lpc21isp
-//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/lpc82x-hal/examples
-//! [GPIO example]: https://github.com/lpc-rs/lpc8xx-hal/blob/master/lpc82x-hal/examples/gpio.rs
+//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/examples
+//! [GPIO example]: https://github.com/lpc-rs/lpc8xx-hal/blob/master/examples/gpio_delay.rs
 //! [available from NXP]: https://www.nxp.com/docs/en/user-guide/UM10800.pdf
 
 #![no_std]
@@ -128,7 +124,7 @@ pub mod syscon;
 pub mod usart;
 pub mod wkt;
 
-/// Re-exports various traits that are required to use lpc82x-hal
+/// Re-exports various traits that are required to use lpc8xx-hal
 ///
 /// The purpose of this module is to improve convenience, by not requiring the
 /// user to import traits separately. Just add the following to your code, and
@@ -208,12 +204,15 @@ pub struct Peripherals {
 
     /// General-purpose I/O (GPIO)
     ///
-    /// The GPIO peripheral is enabled by default. See user manual, section
-    /// 5.6.14.
+    /// By default, the GPIO peripheral is enabled on the LPC82x and disabled on
+    /// the LPC845.
     #[cfg(feature = "82x")]
     pub GPIO: GPIO<init_state::Enabled>,
 
     /// General-purpose I/O (GPIO)
+    ///
+    /// By default, the GPIO peripheral is enabled on the LPC82x and disabled on
+    /// the LPC845.
     #[cfg(feature = "845")]
     pub GPIO: GPIO<init_state::Disabled>,
 

--- a/src/pmu.rs
+++ b/src/pmu.rs
@@ -26,7 +26,7 @@
 //!
 //! Please refer to the [examples in the repository] for more example code.
 //!
-//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/lpc82x-hal/examples
+//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/examples
 
 use cortex_m::{asm, interrupt};
 

--- a/src/swm.rs
+++ b/src/swm.rs
@@ -203,7 +203,7 @@ impl Handle<init_state::Enabled> {
 /// Implemented by types that identify pins
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 /// Please refer to [`Pin`] for the public API used to control pins.
@@ -240,7 +240,7 @@ macro_rules! pins {
         /// # Limitations
         ///
         /// This struct currently provides access to all pins that can be
-        /// available on an LPC82x part. Please make sure that you are aware of
+        /// available on an LPC8xx part. Please make sure that you are aware of
         /// which pins are actually available on your specific part, and only
         /// use those.
         ///
@@ -551,15 +551,15 @@ pins!(
 /// Using the pin for analog input once it is in the ADC state is currently not
 /// supported by this API. If you need this feature, [please let us know](https://github.com/lpc-rs/lpc8xx-hal/issues/51)!
 ///
-/// As a woraround, you can use the raw register mappings from the lpc82x crate,
-/// [`lpc82x::IOCON`] and [`lpc82x::ADC`], after you have put the pin into the
-/// ADC state.
+/// As a wokraround, you can use the raw register mappings from the lpc82x-pac &
+/// lpc845-pac crates, [`lpc82x::IOCON`] and [`lpc82x::ADC`], after you have put
+/// the pin into the ADC state.
 ///
 /// [`direction::Unknown`]: ../gpio/direction/struct.Unknown.html
 /// [`direction::Input`]: ../gpio/direction/struct.Input.html
 /// [`direction::Output`]: ../gpio/direction/struct.Output.html
-/// [`lpc82x::IOCON`]: https://docs.rs/lpc82x/0.4.*/lpc82x/struct.IOCON.html
-/// [`lpc82x::ADC`]: https://docs.rs/lpc82x/0.4.*/lpc82x/struct.ADC.html
+/// [`lpc82x::IOCON`]: https://docs.rs/lpc82x-pac/0.7.*/lpc82x_pac/struct.IOCON.html
+/// [`lpc82x::ADC`]: https://docs.rs/lpc82x-pac/0.7.*/lpc82x_pac/struct.ADC.html
 pub struct Pin<T: PinTrait, S: PinState> {
     pub(crate) ty: T,
     pub(crate) state: S,
@@ -1019,7 +1019,7 @@ impl<T, P> Function<T, state::Assigned<P>> {
 /// Implemented for all fixed and movable functions
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 /// Please refer [`Function::assign`] and [`Function::unassign`] for the public
@@ -1041,7 +1041,7 @@ pub trait FunctionTrait<P: PinTrait> {
 /// Implemented for types that designate whether a function is input or output
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 pub trait FunctionKind {}
 
@@ -1060,7 +1060,7 @@ impl FunctionKind for Analog {}
 /// Internal trait used to assign functions to pins
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 /// Please refer to [`Function::assign`] for the public API that uses this
@@ -1076,7 +1076,7 @@ pub trait AssignFunction<Function, Kind> {
 /// Internal trait used to unassign functions from pins
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 /// Please refer to [`Function::unassign`] for the public API that uses this

--- a/src/syscon.rs
+++ b/src/syscon.rs
@@ -377,7 +377,7 @@ impl UARTFRG {
 /// Internal trait for controlling peripheral clocks
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 /// Please refer to [`syscon::Handle::enable_clock`] and
@@ -474,7 +474,7 @@ impl ClockControl for pac::GPIO {
 /// Internal trait for controlling peripheral reset
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any incompatible changes to this
+/// implemented nor used outside of LPC8xx HAL. Any incompatible changes to this
 /// trait won't be considered breaking changes.
 ///
 /// Please refer to [`syscon::Handle::assert_reset`] and
@@ -565,7 +565,7 @@ impl<'a> ResetControl for pac::GPIO {
 /// Internal trait for powering analog blocks
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 /// Please refer to [`syscon::Handle::power_up`] and
@@ -677,7 +677,7 @@ impl clock::Enabled for IoscDerivedClock<init_state::Enabled> {}
 /// Internal trait used to configure interrupt wake-up
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 /// Please refer to [`syscon::Handle::enable_interrupt_wakeup`] and
@@ -733,7 +733,7 @@ wakeup_interrupt!(I2c3Wakeup, i2c3);
 /// Internal trait used configure clocking of peripheals
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 ///
 pub trait PeripheralClock<PERIPH> {

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -53,7 +53,7 @@
 //!
 //! Please refer to the [examples in the repository] for more example code.
 //!
-//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/lpc82x-hal/examples
+//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/examples
 
 use core::fmt;
 use core::ops::Deref;
@@ -390,7 +390,7 @@ where
 /// Internal trait for USART peripherals
 ///
 /// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC82x HAL. Any changes to this trait won't
+/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
 pub trait Peripheral:
     Deref<Target = pac::usart0::RegisterBlock>

--- a/src/wkt.rs
+++ b/src/wkt.rs
@@ -29,7 +29,7 @@
 //!
 //! Please refer to the [examples in the repository] for more example code.
 //!
-//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/lpc82x-hal/examples
+//! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/examples
 
 use embedded_hal::timer;
 use nb;


### PR DESCRIPTION
- Fix broken links
- Replace references to lpc82x-hal with lpc8xx-hal

This didn't fix any doc examples