### PR TITLE
Implement MRT abstraction

### DIFF
--- a/examples/gpio_timer.rs
+++ b/examples/gpio_timer.rs
@@ -1,0 +1,48 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_halt;
+
+use lpc8xx_hal::{cortex_m_rt::entry, prelude::*, Peripherals};
+
+use nb::block;
+#[entry]
+fn main() -> ! {
+    // Get access to the device's peripherals. Since only one instance of this
+    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // If we tried to call the method a second time, it would return `None`, but
+    // we're only calling it the one time here, so we can safely `unwrap` the
+    // `Option` without causing a panic.
+    let p = Peripherals::take().unwrap();
+
+    // Initialize the APIs of the peripherals we need.
+    let swm = p.SWM.split();
+    let mut syscon = p.SYSCON.split();
+    let [mut timer, _, _, _] = p.MRT0.split(&mut syscon.handle);
+
+    #[cfg(feature = "82x")]
+    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    #[cfg(feature = "845")]
+    let gpio = p.GPIO.enable(&mut syscon.handle);
+
+    // Select pin for LED
+    #[cfg(feature = "82x")]
+    let led = swm.pins.pio0_12;
+    #[cfg(feature = "845")]
+    let led = swm.pins.pio1_1;
+
+    // Configure the LED pin. The API tracks the state of pins at compile time,
+    // to prevent any mistakes.
+    let mut led = led.into_gpio_pin(&gpio).into_output();
+
+    // Start the timer with an intervall of 12_000_000 ticks
+    timer.start(12_000_000u32);
+
+    // Blink the LED using the systick with the delay traits
+    loop {
+        block!(timer.wait()).unwrap();
+        led.set_high().unwrap();
+        block!(timer.wait()).unwrap();
+        led.set_low().unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,7 @@ pub mod dma;
 pub mod gpio;
 #[cfg(feature = "82x")]
 pub mod i2c;
+pub mod mrtimer;
 pub mod pmu;
 pub mod sleep;
 pub mod swm;
@@ -159,6 +160,7 @@ pub use self::dma::DMA;
 pub use self::gpio::GPIO;
 #[cfg(feature = "82x")]
 pub use self::i2c::I2C;
+pub use self::mrtimer::MRTimer;
 pub use self::pmu::PMU;
 pub use self::swm::SWM;
 pub use self::syscon::SYSCON;
@@ -220,6 +222,9 @@ pub struct Peripherals {
     /// I2C0-bus interface
     #[cfg(feature = "82x")]
     pub I2C0: I2C<init_state::Disabled>,
+
+    /// Multi-Rate Timer (MRT)
+    pub MRT0: MRTimer,
 
     /// Power Management Unit
     pub PMU: PMU,
@@ -367,13 +372,6 @@ pub struct Peripherals {
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
     pub IOCON: pac::IOCON,
-
-    /// Multi-Rate Timer (MRT)
-    ///
-    /// A HAL API for this peripheral has not been implemented yet. In the
-    /// meantime, this field provides you with the raw register mappings, which
-    /// allow you full, unprotected access to the peripheral.
-    pub MRT0: pac::MRT0,
 
     /// Pin interrupt and pattern match engine
     ///
@@ -541,6 +539,7 @@ impl Peripherals {
             GPIO: GPIO::new(p.GPIO),
             #[cfg(feature = "82x")]
             I2C0: I2C::new(p.I2C0),
+            MRT0: MRTimer::new(p.MRT0),
             PMU: PMU::new(p.PMU),
             #[cfg(feature = "82x")]
             SWM: unsafe { SWM::new_enabled(p.SWM0) },
@@ -574,7 +573,6 @@ impl Peripherals {
             I2C3: p.I2C3,
             INPUTMUX: p.INPUTMUX,
             IOCON: p.IOCON,
-            MRT0: p.MRT0,
             PINT: p.PINT,
             SCT0: p.SCT0,
             SPI0: p.SPI0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ pub mod dma;
 pub mod gpio;
 #[cfg(feature = "82x")]
 pub mod i2c;
-pub mod mrtimer;
+pub mod mrt;
 pub mod pmu;
 pub mod sleep;
 pub mod swm;
@@ -160,7 +160,7 @@ pub use self::dma::DMA;
 pub use self::gpio::GPIO;
 #[cfg(feature = "82x")]
 pub use self::i2c::I2C;
-pub use self::mrtimer::MRTimer;
+pub use self::mrt::MRT;
 pub use self::pmu::PMU;
 pub use self::swm::SWM;
 pub use self::syscon::SYSCON;
@@ -224,7 +224,7 @@ pub struct Peripherals {
     pub I2C0: I2C<init_state::Disabled>,
 
     /// Multi-Rate Timer (MRT)
-    pub MRT0: MRTimer,
+    pub MRT0: MRT,
 
     /// Power Management Unit
     pub PMU: PMU,
@@ -539,7 +539,7 @@ impl Peripherals {
             GPIO: GPIO::new(p.GPIO),
             #[cfg(feature = "82x")]
             I2C0: I2C::new(p.I2C0),
-            MRT0: MRTimer::new(p.MRT0),
+            MRT0: MRT::new(p.MRT0),
             PMU: PMU::new(p.PMU),
             #[cfg(feature = "82x")]
             SWM: unsafe { SWM::new_enabled(p.SWM0) },

--- a/src/mrt.rs
+++ b/src/mrt.rs
@@ -35,17 +35,17 @@ use nb::{Error, Result};
 use void::Void;
 
 /// Represent a MRT0 instance
-pub struct MRTimer {
+pub struct MRT {
     mrt: MRT0,
 }
 
 /// Represent a MRT0 channel
-pub struct MRTimerChannel {
+pub struct MrtChannel {
     channel: u8,
     channels: RegProxy<CHANNEL>,
 }
 
-impl MRTimer {
+impl MRT {
     /// Assumes peripheral is in reset state
     ///
     /// This means:
@@ -55,23 +55,23 @@ impl MRTimer {
         Self { mrt }
     }
 
-    /// Enables the MRTimer and splits it into it's four channels
-    pub fn split(self, syscon: &mut syscon::Handle) -> [MRTimerChannel; 4] {
+    /// Enables the MRT and splits it into it's four channels
+    pub fn split(self, syscon: &mut syscon::Handle) -> [MrtChannel; 4] {
         syscon.enable_clock(&self.mrt);
         [
-            MRTimerChannel {
+            MrtChannel {
                 channel: 0,
                 channels: RegProxy::new(),
             },
-            MRTimerChannel {
+            MrtChannel {
                 channel: 1,
                 channels: RegProxy::new(),
             },
-            MRTimerChannel {
+            MrtChannel {
                 channel: 2,
                 channels: RegProxy::new(),
             },
-            MRTimerChannel {
+            MrtChannel {
                 channel: 3,
                 channels: RegProxy::new(),
             },
@@ -95,8 +95,7 @@ impl MRTimer {
     }
 }
 
-// TODO the lpc82x um isn't quite clear on how many bits the mrt has
-impl CountDown for MRTimerChannel {
+impl CountDown for MrtChannel {
     /// The timer operates in clock ticks from the system clock, that means it
     /// runs at 12_000_000 ticks per second if you haven't changed it.
     ///
@@ -141,6 +140,6 @@ impl CountDown for MRTimerChannel {
     }
 }
 
-impl Periodic for MRTimerChannel {}
+impl Periodic for MrtChannel {}
 
 reg!(CHANNEL, [CHANNEL; 4], MRT0, channel);


### PR DESCRIPTION
TODO:
- Check what's up on the lpc82x

  The UM says it's a 31 bit timer, but the documentation for MODCFG.NOB suggests 24 bits
  
  @hannobraun Could you check? I unfortunately don't have an lpc82x device