### PR TITLE
Remove core peripherals from `Peripherals`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,10 @@ name              = "adc"
 required-features = ["rt-selected", "845"]
 
 [[example]]
+name              = "rtfm"
+required-features = ["845"]
+
+[[example]]
 name              = "spi_apa102"
 required-features = ["rt-selected"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ version      = "0.3.0"
 
 
 [dev-dependencies]
-panic-halt = "0.2.0"
+panic-halt    = "0.2.0"
+cortex-m-rtfm = "0.5.1"
 
 
 [build-dependencies]

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -13,14 +13,15 @@ use lpc8xx_hal::{
     delay::Delay,
     prelude::*,
     syscon::clocksource::{AdcClock, UsartClock},
-    Peripherals,
+    CorePeripherals, Peripherals,
 };
 
 #[entry]
 fn main() -> ! {
+    let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 
-    let mut delay = Delay::new(p.SYST);
+    let mut delay = Delay::new(cp.SYST);
     let swm = p.SWM.split();
     let mut syscon = p.SYSCON.split();
 

--- a/examples/ctimer_fade.rs
+++ b/examples/ctimer_fade.rs
@@ -3,7 +3,9 @@
 
 extern crate panic_halt;
 
-use lpc8xx_hal::{cortex_m_rt::entry, delay::Delay, prelude::*, Peripherals};
+use lpc8xx_hal::{
+    cortex_m_rt::entry, delay::Delay, prelude::*, CorePeripherals, Peripherals,
+};
 
 #[entry]
 fn main() -> ! {
@@ -12,11 +14,12 @@ fn main() -> ! {
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
+    let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
     let swm = p.SWM.split();
-    let mut delay = Delay::new(p.SYST);
+    let mut delay = Delay::new(cp.SYST);
     let mut syscon = p.SYSCON.split();
 
     let mut handle = swm.handle.enable(&mut syscon.handle);

--- a/examples/gpio_delay.rs
+++ b/examples/gpio_delay.rs
@@ -3,7 +3,9 @@
 
 extern crate panic_halt;
 
-use lpc8xx_hal::{cortex_m_rt::entry, delay::Delay, prelude::*, Peripherals};
+use lpc8xx_hal::{
+    cortex_m_rt::entry, delay::Delay, prelude::*, CorePeripherals, Peripherals,
+};
 
 #[entry]
 fn main() -> ! {
@@ -12,11 +14,12 @@ fn main() -> ! {
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
+    let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
     let swm = p.SWM.split();
-    let mut delay = Delay::new(p.SYST);
+    let mut delay = Delay::new(cp.SYST);
     #[cfg(feature = "82x")]
     let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
     #[cfg(feature = "845")]

--- a/examples/i2c_eeprom.rs
+++ b/examples/i2c_eeprom.rs
@@ -19,14 +19,15 @@ use lpc8xx_hal::{
     delay::Delay,
     prelude::*,
     syscon::clocksource::{I2cClock, UsartClock},
-    Peripherals,
+    CorePeripherals, Peripherals,
 };
 
 #[entry]
 fn main() -> ! {
+    let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 
-    let mut delay = Delay::new(p.SYST);
+    let mut delay = Delay::new(cp.SYST);
     let i2c = p.I2C0;
     let swm = p.SWM.split();
     let mut syscon = p.SYSCON.split();

--- a/examples/pmu.rs
+++ b/examples/pmu.rs
@@ -12,11 +12,12 @@ use lpc8xx_hal::{
     prelude::*,
     syscon::clocksource::UsartClock,
     syscon::WktWakeup,
-    Peripherals,
+    CorePeripherals, Peripherals,
 };
 
 #[entry]
 fn main() -> ! {
+    let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 
     let mut pmu = p.PMU.split();
@@ -52,7 +53,7 @@ fn main() -> ! {
     // Need to re-assign some stuff that's needed inside the closure. Otherwise
     // it will try to move stuff that's still borrowed outside of it.
     let mut pmu = pmu.handle;
-    let mut scb = p.SCB;
+    let mut scb = cp.SCB;
     let mut syscon = syscon.handle;
 
     interrupt::free(|_| {

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -1,0 +1,28 @@
+#![no_main]
+#![no_std]
+
+use lpc8xx_hal::{delay::Delay, prelude::*, Peripherals};
+use panic_halt as _;
+
+#[rtfm::app(device = lpc8xx_hal::pac)]
+const APP: () = {
+    #[init]
+    fn init(cx: init::Context) {
+        let p = Peripherals::take().unwrap();
+
+        let mut delay = Delay::new(cx.core.SYST);
+
+        let mut syscon = p.SYSCON.split();
+        let swm = p.SWM.split();
+        let gpio = p.GPIO.enable(&mut syscon.handle);
+
+        let mut led = swm.pins.pio1_1.into_gpio_pin(&gpio).into_output();
+
+        loop {
+            led.set_high().unwrap();
+            delay.delay_ms(700_u16);
+            led.set_low().unwrap();
+            delay.delay_ms(50_u16);
+        }
+    }
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,8 @@ pub use self::syscon::SYSCON;
 pub use self::usart::USART;
 pub use self::wkt::WKT;
 
+pub use pac::CorePeripherals;
+
 use embedded_hal as hal;
 
 /// Provides access to all peripherals
@@ -387,41 +389,6 @@ pub struct Peripherals {
     /// meantime, this field provides you with the raw register mappings, which
     /// allow you full, unprotected access to the peripheral.
     pub WWDT: pac::WWDT,
-
-    /// CPUID
-    ///
-    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
-    pub CPUID: pac::CPUID,
-
-    /// Debug Control Block (DCB)
-    ///
-    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
-    pub DCB: pac::DCB,
-
-    /// Data Watchpoint and Trace unit (DWT)
-    ///
-    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
-    pub DWT: pac::DWT,
-
-    /// Memory Protection Unit (MPU)
-    ///
-    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
-    pub MPU: pac::MPU,
-
-    /// Nested Vector Interrupt Controller (NVIC)
-    ///
-    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
-    pub NVIC: pac::NVIC,
-
-    /// System Control Block (SCB)
-    ///
-    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
-    pub SCB: pac::SCB,
-
-    /// SysTick: System Timer
-    ///
-    /// This is a core peripherals that's available on all ARM Cortex-M0+ cores.
-    pub SYST: pac::SYST,
 }
 
 impl Peripherals {
@@ -455,10 +422,7 @@ impl Peripherals {
     /// let p = Peripherals::take().unwrap();
     /// ```
     pub fn take() -> Option<Self> {
-        Some(Self::new(
-            pac::Peripherals::take()?,
-            pac::CorePeripherals::take()?,
-        ))
+        Some(Self::new(pac::Peripherals::take()?))
     }
 
     /// Steal the peripherals
@@ -502,10 +466,10 @@ impl Peripherals {
     /// Since there are no means within this API to forcibly change type state,
     /// you will need to resort to something like [`core::mem::transmute`].
     pub unsafe fn steal() -> Self {
-        Self::new(pac::Peripherals::steal(), pac::CorePeripherals::steal())
+        Self::new(pac::Peripherals::steal())
     }
 
-    fn new(p: pac::Peripherals, cp: pac::CorePeripherals) -> Self {
+    fn new(p: pac::Peripherals) -> Self {
         Peripherals {
             // HAL peripherals
             ADC: ADC::new(p.ADC0),
@@ -555,15 +519,6 @@ impl Peripherals {
             PINT: p.PINT,
             SCT0: p.SCT0,
             WWDT: p.WWDT,
-
-            // Core peripherals
-            CPUID: cp.CPUID,
-            DCB: cp.DCB,
-            DWT: cp.DWT,
-            MPU: cp.MPU,
-            NVIC: cp.NVIC,
-            SCB: cp.SCB,
-            SYST: cp.SYST,
         }
     }
 }


### PR DESCRIPTION
The point of this is to improve interoperability with RTFM. Interoperability is still not very good (due to the lifetimes requires all over the API), but it's a start.