### PR TITLE
Make dependency on Termion optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,11 @@ panic-halt    = "0.2.0"
 cortex-m-rtfm = "0.5.1"
 
 
-[build-dependencies]
-termion = "1.5.3"
+# Termion has been made optional, as it doesn't build on Windows:
+# https://gitlab.redox-os.org/redox-os/termion/issues/167
+[build-dependencies.termion]
+version  = "1.5.3"
+optional = true
 
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ use std::{
     path::PathBuf,
 };
 
+#[cfg(feature = "termion")]
 use termion::{color, style};
 
 fn main() -> Result<(), Error> {
@@ -150,6 +151,10 @@ impl From<io::Error> for Error {
 }
 
 fn error(message: &str) -> ! {
+    #[cfg(not(feature = "termion"))]
+    panic!("\n\n\n{}\n\n\n", message);
+
+    #[cfg(feature = "termion")]
     panic!(
         "\n\n\n{}{}{}{}{}\n\n\n",
         style::Bold,


### PR DESCRIPTION
It doesn't build on Windows, which I think is enough reason to make it
optional and unselected by default.

I don't think having it as an optional dependency is particularly
useful, but I didn't want to remove it outright. I'm hoping that
Termion's problems on Windows are temporary, and once it is fixed,
restoring the previous functionality will be easy.

Close #212