### PR TITLE
Rename `Peripherals` to `Device`

### DIFF
--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -10,40 +10,41 @@ use nb::block;
 
 use lpc8xx_hal::{
     cortex_m_rt::entry, delay::Delay, prelude::*,
-    syscon::clock_source::AdcClock, usart, CorePeripherals, Peripherals,
+    syscon::clock_source::AdcClock, usart, CorePeripherals, Device,
 };
 
 #[entry]
 fn main() -> ! {
     let cp = CorePeripherals::take().unwrap();
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
     let mut delay = Delay::new(cp.SYST);
-    let swm = p.SWM.split();
-    let mut syscon = p.SYSCON.split();
+    let swm = device.SWM.split();
+    let mut syscon = device.SYSCON.split();
 
     let mut handle = swm.handle.enable(&mut syscon.handle); // SWM isn't enabled by default on LPC845.
 
     // Set baud rate to 115200 baud
     let clock_config = usart::Clock::new_with_baudrate(115200);
 
-    let tx_pin = p.pins.pio0_25.into_swm_pin();
-    let rx_pin = p.pins.pio0_24.into_swm_pin();
+    let tx_pin = device.pins.pio0_25.into_swm_pin();
+    let rx_pin = device.pins.pio0_24.into_swm_pin();
 
     let (u0_rxd, _) = swm.movable_functions.u0_rxd.assign(rx_pin, &mut handle);
     let (u0_txd, _) = swm.movable_functions.u0_txd.assign(tx_pin, &mut handle);
 
     let mut serial =
-        p.USART0
+        device
+            .USART0
             .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
 
     let adc_clock = AdcClock::new_default();
-    let mut adc = p.ADC.enable(&adc_clock, &mut syscon.handle);
+    let mut adc = device.ADC.enable(&adc_clock, &mut syscon.handle);
 
     let (mut adc_pin, _) = swm
         .fixed_functions
         .adc_0
-        .assign(p.pins.pio0_7.into_swm_pin(), &mut handle);
+        .assign(device.pins.pio0_7.into_swm_pin(), &mut handle);
 
     loop {
         let adc_value =

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -15,10 +15,10 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
-    let cp = CorePeripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
     let device = Device::take().unwrap();
 
-    let mut delay = Delay::new(cp.SYST);
+    let mut delay = Delay::new(core.SYST);
     let swm = device.SWM.split();
     let mut syscon = device.SYSCON.split();
 

--- a/examples/ctimer_fade.rs
+++ b/examples/ctimer_fade.rs
@@ -4,7 +4,7 @@
 extern crate panic_halt;
 
 use lpc8xx_hal::{
-    cortex_m_rt::entry, delay::Delay, prelude::*, CorePeripherals, Peripherals,
+    cortex_m_rt::entry, delay::Delay, prelude::*, CorePeripherals, Device,
 };
 
 #[entry]
@@ -15,23 +15,23 @@ fn main() -> ! {
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
     let cp = CorePeripherals::take().unwrap();
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
-    let swm = p.SWM.split();
+    let swm = device.SWM.split();
     let mut delay = Delay::new(cp.SYST);
-    let mut syscon = p.SYSCON.split();
+    let mut syscon = device.SYSCON.split();
 
     let mut handle = swm.handle.enable(&mut syscon.handle);
 
     // Use 8 bit pwm
     let (red_pwm, green_pwm, blue_pwm) =
-        p.CTIMER0.start_pwm(256, 0, &mut syscon.handle);
+        device.CTIMER0.start_pwm(256, 0, &mut syscon.handle);
 
     // Select pin for the RGB LED
-    let green = p.pins.pio1_0.into_swm_pin();
-    let blue = p.pins.pio1_1.into_swm_pin();
-    let red = p.pins.pio1_2.into_swm_pin();
+    let green = device.pins.pio1_0.into_swm_pin();
+    let blue = device.pins.pio1_1.into_swm_pin();
+    let red = device.pins.pio1_2.into_swm_pin();
 
     // Configure the LED pins. The API tracks the state of pins at compile time,
     // to prevent any mistakes.

--- a/examples/ctimer_fade.rs
+++ b/examples/ctimer_fade.rs
@@ -14,12 +14,12 @@ fn main() -> ! {
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
-    let cp = CorePeripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
     let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
     let swm = device.SWM.split();
-    let mut delay = Delay::new(cp.SYST);
+    let mut delay = Delay::new(core.SYST);
     let mut syscon = device.SYSCON.split();
 
     let mut handle = swm.handle.enable(&mut syscon.handle);

--- a/examples/gpio_delay.rs
+++ b/examples/gpio_delay.rs
@@ -15,11 +15,11 @@ fn main() -> ! {
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
-    let cp = CorePeripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
     let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
-    let mut delay = Delay::new(cp.SYST);
+    let mut delay = Delay::new(core.SYST);
     #[cfg(feature = "82x")]
     let gpio = device.GPIO; // GPIO is initialized by default on LPC82x.
     #[cfg(feature = "845")]

--- a/examples/gpio_delay.rs
+++ b/examples/gpio_delay.rs
@@ -5,34 +5,34 @@ extern crate panic_halt;
 
 use lpc8xx_hal::{
     cortex_m_rt::entry, delay::Delay, gpio::Level, prelude::*, CorePeripherals,
-    Peripherals,
+    Device,
 };
 
 #[entry]
 fn main() -> ! {
     // Get access to the device's peripherals. Since only one instance of this
-    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // struct can exist, the call to `take` returns an `Option<Device>`.
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
     let cp = CorePeripherals::take().unwrap();
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
     let mut delay = Delay::new(cp.SYST);
     #[cfg(feature = "82x")]
-    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    let gpio = device.GPIO; // GPIO is initialized by default on LPC82x.
     #[cfg(feature = "845")]
     let gpio = {
-        let mut syscon = p.SYSCON.split();
-        p.GPIO.enable(&mut syscon.handle)
+        let mut syscon = device.SYSCON.split();
+        device.GPIO.enable(&mut syscon.handle)
     };
 
     // Select pin for LED
     #[cfg(feature = "82x")]
-    let (led, token) = (p.pins.pio0_12, gpio.tokens.pio0_12);
+    let (led, token) = (device.pins.pio0_12, gpio.tokens.pio0_12);
     #[cfg(feature = "845")]
-    let (led, token) = (p.pins.pio1_1, gpio.tokens.pio1_1);
+    let (led, token) = (device.pins.pio1_1, gpio.tokens.pio1_1);
 
     // Configure the LED pin. The API tracks the state of pins at compile time,
     // to prevent any mistakes.

--- a/examples/gpio_input.rs
+++ b/examples/gpio_input.rs
@@ -3,28 +3,28 @@
 
 extern crate panic_halt;
 
-use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, prelude::*, Peripherals};
+use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, prelude::*, Device};
 
 #[entry]
 fn main() -> ! {
     // Get access to the device's peripherals. Since only one instance of this
-    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // struct can exist, the call to `take` returns an `Option<Device>`.
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
     let gpio = {
-        let mut syscon = p.SYSCON.split();
-        p.GPIO.enable(&mut syscon.handle)
+        let mut syscon = device.SYSCON.split();
+        device.GPIO.enable(&mut syscon.handle)
     };
 
     // Select pin for LED
-    let led = p.pins.pio1_1;
+    let led = device.pins.pio1_1;
 
     // Select pin for button
-    let button = p.pins.pio0_4;
+    let button = device.pins.pio0_4;
 
     // Configure the LED pin. The API tracks the state of pins at compile time,
     // to prevent any mistakes.

--- a/examples/gpio_simple.rs
+++ b/examples/gpio_simple.rs
@@ -3,31 +3,31 @@
 
 extern crate panic_halt;
 
-use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, prelude::*, Peripherals};
+use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, prelude::*, Device};
 
 #[entry]
 fn main() -> ! {
     // Get access to the device's peripherals. Since only one instance of this
-    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // struct can exist, the call to `take` returns an `Option<Device>`.
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
     #[cfg(feature = "82x")]
-    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    let gpio = device.GPIO; // GPIO is initialized by default on LPC82x.
     #[cfg(feature = "845")]
     let gpio = {
-        let mut syscon = p.SYSCON.split();
-        p.GPIO.enable(&mut syscon.handle)
+        let mut syscon = device.SYSCON.split();
+        device.GPIO.enable(&mut syscon.handle)
     };
 
     // Select pin for LED
     #[cfg(feature = "82x")]
-    let (led, token) = (p.pins.pio0_12, gpio.tokens.pio0_12);
+    let (led, token) = (device.pins.pio0_12, gpio.tokens.pio0_12);
     #[cfg(feature = "845")]
-    let (led, token) = (p.pins.pio1_1, gpio.tokens.pio1_1);
+    let (led, token) = (device.pins.pio1_1, gpio.tokens.pio1_1);
 
     // Configure the LED pin. The API tracks the state of pins at compile time,
     // to prevent any mistakes.

--- a/examples/gpio_sleep.rs
+++ b/examples/gpio_sleep.rs
@@ -4,8 +4,7 @@
 extern crate panic_halt;
 
 use lpc8xx_hal::{
-    clock::Ticks, cortex_m_rt::entry, gpio::Level, prelude::*, sleep,
-    Peripherals,
+    clock::Ticks, cortex_m_rt::entry, gpio::Level, prelude::*, sleep, Device,
 };
 
 #[entry]
@@ -15,15 +14,15 @@ fn main() -> ! {
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
-    let mut syscon = p.SYSCON.split();
-    let mut wkt = p.WKT.enable(&mut syscon.handle);
+    let mut syscon = device.SYSCON.split();
+    let mut wkt = device.WKT.enable(&mut syscon.handle);
     #[cfg(feature = "82x")]
-    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    let gpio = device.GPIO; // GPIO is initialized by default on LPC82x.
     #[cfg(feature = "845")]
-    let gpio = p.GPIO.enable(&mut syscon.handle);
+    let gpio = device.GPIO.enable(&mut syscon.handle);
 
     // We're going to need a clock for sleeping. Let's use the internal oscillator/IRC/FRO-derived clock
     // that runs at 750 kHz.
@@ -31,9 +30,9 @@ fn main() -> ! {
 
     // Select pin for LED
     #[cfg(feature = "82x")]
-    let (led, token) = (p.pins.pio0_12, gpio.tokens.pio0_12);
+    let (led, token) = (device.pins.pio0_12, gpio.tokens.pio0_12);
     #[cfg(feature = "845")]
-    let (led, token) = (p.pins.pio1_1, gpio.tokens.pio1_1);
+    let (led, token) = (device.pins.pio1_1, gpio.tokens.pio1_1);
 
     // Configure the LED pin. The API tracks the state of pins at compile time,
     // to prevent any mistakes.

--- a/examples/gpio_timer.rs
+++ b/examples/gpio_timer.rs
@@ -3,32 +3,32 @@
 
 extern crate panic_halt;
 
-use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, prelude::*, Peripherals};
+use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, prelude::*, Device};
 
 use nb::block;
 #[entry]
 fn main() -> ! {
     // Get access to the device's peripherals. Since only one instance of this
-    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // struct can exist, the call to `take` returns an `Option<Device>`.
     // If we tried to call the method a second time, it would return `None`, but
     // we're only calling it the one time here, so we can safely `unwrap` the
     // `Option` without causing a panic.
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
     // Initialize the APIs of the peripherals we need.
-    let mut syscon = p.SYSCON.split();
-    let [mut timer, _, _, _] = p.MRT0.split(&mut syscon.handle);
+    let mut syscon = device.SYSCON.split();
+    let [mut timer, _, _, _] = device.MRT0.split(&mut syscon.handle);
 
     #[cfg(feature = "82x")]
-    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    let gpio = device.GPIO; // GPIO is initialized by default on LPC82x.
     #[cfg(feature = "845")]
-    let gpio = p.GPIO.enable(&mut syscon.handle);
+    let gpio = device.GPIO.enable(&mut syscon.handle);
 
     // Select pin for LED
     #[cfg(feature = "82x")]
-    let (led, token) = (p.pins.pio0_12, gpio.tokens.pio0_12);
+    let (led, token) = (device.pins.pio0_12, gpio.tokens.pio0_12);
     #[cfg(feature = "845")]
-    let (led, token) = (p.pins.pio1_1, gpio.tokens.pio1_1);
+    let (led, token) = (device.pins.pio1_1, gpio.tokens.pio1_1);
 
     // Configure the LED pin. The API tracks the state of pins at compile time,
     // to prevent any mistakes.

--- a/examples/i2c_eeprom.rs
+++ b/examples/i2c_eeprom.rs
@@ -21,10 +21,10 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
-    let cp = CorePeripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
     let device = Device::take().unwrap();
 
-    let mut delay = Delay::new(cp.SYST);
+    let mut delay = Delay::new(core.SYST);
     let i2c = device.I2C0;
     let swm = device.SWM.split();
     let mut syscon = device.SYSCON.split();

--- a/examples/i2c_vl53l0x.rs
+++ b/examples/i2c_vl53l0x.rs
@@ -17,16 +17,16 @@ use core::fmt::Write;
 
 use lpc8xx_hal::{
     cortex_m_rt::entry, prelude::*, syscon::clock_source::I2cClock, usart,
-    Peripherals,
+    Device,
 };
 
 #[entry]
 fn main() -> ! {
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
-    let i2c = p.I2C0;
-    let mut swm = p.SWM.split();
-    let mut syscon = p.SYSCON.split();
+    let i2c = device.I2C0;
+    let mut swm = device.SWM.split();
+    let mut syscon = device.SYSCON.split();
 
     // Set baud rate to 115200 baud
     //
@@ -58,13 +58,13 @@ fn main() -> ! {
     let (u0_rxd, _) = swm
         .movable_functions
         .u0_rxd
-        .assign(p.pins.pio0_0.into_swm_pin(), &mut swm.handle);
+        .assign(device.pins.pio0_0.into_swm_pin(), &mut swm.handle);
     let (u0_txd, _) = swm
         .movable_functions
         .u0_txd
-        .assign(p.pins.pio0_4.into_swm_pin(), &mut swm.handle);
+        .assign(device.pins.pio0_4.into_swm_pin(), &mut swm.handle);
 
-    let mut serial = p.USART0.enable(
+    let mut serial = device.USART0.enable(
         &usart::Clock::new(&syscon.uartfrg, 0, 16),
         &mut syscon.handle,
         u0_rxd,
@@ -78,11 +78,11 @@ fn main() -> ! {
     let (i2c0_sda, _) = swm
         .fixed_functions
         .i2c0_sda
-        .assign(p.pins.pio0_11.into_swm_pin(), &mut swm.handle);
+        .assign(device.pins.pio0_11.into_swm_pin(), &mut swm.handle);
     let (i2c0_scl, _) = swm
         .fixed_functions
         .i2c0_scl
-        .assign(p.pins.pio0_10.into_swm_pin(), &mut swm.handle);
+        .assign(device.pins.pio0_10.into_swm_pin(), &mut swm.handle);
 
     let i2c_clock = I2cClock::new_400khz();
     let mut i2c =

--- a/examples/pmu.rs
+++ b/examples/pmu.rs
@@ -16,7 +16,7 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
-    let cp = CorePeripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
     let device = Device::take().unwrap();
 
     let mut pmu = device.PMU.split();
@@ -53,7 +53,7 @@ fn main() -> ! {
     // Need to re-assign some stuff that's needed inside the closure. Otherwise
     // it will try to move stuff that's still borrowed outside of it.
     let mut pmu = pmu.handle;
-    let mut scb = cp.SCB;
+    let mut scb = core.SCB;
     let mut syscon = syscon.handle;
 
     interrupt::free(|_| {

--- a/examples/pmu.rs
+++ b/examples/pmu.rs
@@ -11,17 +11,17 @@ use lpc8xx_hal::{
     pmu::LowPowerClock,
     prelude::*,
     syscon::WktWakeup,
-    usart, CorePeripherals, Peripherals,
+    usart, CorePeripherals, Device,
 };
 
 #[entry]
 fn main() -> ! {
     let cp = CorePeripherals::take().unwrap();
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
-    let mut pmu = p.PMU.split();
-    let mut swm = p.SWM.split();
-    let mut syscon = p.SYSCON.split();
+    let mut pmu = device.PMU.split();
+    let mut swm = device.SWM.split();
+    let mut syscon = device.SYSCON.split();
 
     // 115200 baud
     syscon.uartfrg.set_clkdiv(6);
@@ -32,19 +32,20 @@ fn main() -> ! {
     let (u0_rxd, _) = swm
         .movable_functions
         .u0_rxd
-        .assign(p.pins.pio0_0.into_swm_pin(), &mut swm.handle);
+        .assign(device.pins.pio0_0.into_swm_pin(), &mut swm.handle);
     let (u0_txd, _) = swm
         .movable_functions
         .u0_txd
-        .assign(p.pins.pio0_4.into_swm_pin(), &mut swm.handle);
+        .assign(device.pins.pio0_4.into_swm_pin(), &mut swm.handle);
 
     let mut serial =
-        p.USART0
+        device
+            .USART0
             .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
 
     let _ = pmu.low_power_clock.enable(&mut pmu.handle);
 
-    let mut wkt = p.WKT.enable(&mut syscon.handle);
+    let mut wkt = device.WKT.enable(&mut syscon.handle);
     wkt.select_clock::<LowPowerClock>();
 
     let five_seconds: u32 = 10_000 * 5;

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -6,7 +6,7 @@ use lpc8xx_hal::{
     gpio::{direction::Output, GpioPin, Level},
     pins::PIO1_1,
     prelude::*,
-    Peripherals,
+    Device,
 };
 use panic_halt as _;
 
@@ -19,14 +19,14 @@ const APP: () = {
 
     #[init]
     fn init(cx: init::Context) -> init::LateResources {
-        let p = Peripherals::take().unwrap();
+        let device = Device::take().unwrap();
 
         let delay = Delay::new(cx.core.SYST);
 
-        let mut syscon = p.SYSCON.split();
-        let gpio = p.GPIO.enable(&mut syscon.handle);
+        let mut syscon = device.SYSCON.split();
+        let gpio = device.GPIO.enable(&mut syscon.handle);
 
-        let led = p
+        let led = device
             .pins
             .pio1_1
             .into_output_pin(gpio.tokens.pio1_1, Level::Low);

--- a/examples/spi_apa102.rs
+++ b/examples/spi_apa102.rs
@@ -4,7 +4,7 @@
 extern crate panic_halt;
 
 use lpc8xx_hal::{
-    cortex_m_rt::entry, prelude::*, syscon::clock_source::SpiClock, Peripherals,
+    cortex_m_rt::entry, prelude::*, syscon::clock_source::SpiClock, Device,
 };
 
 use embedded_hal::spi::{Mode, Phase, Polarity};
@@ -15,19 +15,19 @@ fn main() -> ! {
         polarity: Polarity::IdleHigh,
         phase: Phase::CaptureOnSecondTransition,
     };
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
-    let swm = p.SWM.split();
-    let mut syscon = p.SYSCON.split();
+    let swm = device.SWM.split();
+    let mut syscon = device.SYSCON.split();
 
     #[cfg(feature = "82x")]
     let mut handle = swm.handle;
     #[cfg(feature = "845")]
     let mut handle = swm.handle.enable(&mut syscon.handle); // SWM isn't enabled by default on LPC845.
 
-    let sck_pin = p.pins.pio0_13.into_swm_pin();
-    let mosi_pin = p.pins.pio0_14.into_swm_pin();
-    let miso_pin = p.pins.pio0_15.into_swm_pin();
+    let sck_pin = device.pins.pio0_13.into_swm_pin();
+    let mosi_pin = device.pins.pio0_14.into_swm_pin();
+    let miso_pin = device.pins.pio0_15.into_swm_pin();
 
     let (spi0_sck, _) =
         swm.movable_functions.spi0_sck.assign(sck_pin, &mut handle);
@@ -46,7 +46,7 @@ fn main() -> ! {
     let spi_clock = SpiClock::new(&syscon.iosc, 0);
 
     // Enable SPI0
-    let mut spi = p.SPI0.enable(
+    let mut spi = device.SPI0.enable(
         &spi_clock,
         &mut syscon.handle,
         MODE,

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -3,14 +3,14 @@
 
 extern crate panic_halt;
 
-use lpc8xx_hal::{cortex_m_rt::entry, prelude::*, usart, Peripherals};
+use lpc8xx_hal::{cortex_m_rt::entry, prelude::*, usart, Device};
 
 #[entry]
 fn main() -> ! {
-    let p = Peripherals::take().unwrap();
+    let device = Device::take().unwrap();
 
-    let swm = p.SWM.split();
-    let mut syscon = p.SYSCON.split();
+    let swm = device.SWM.split();
+    let mut syscon = device.SYSCON.split();
 
     #[cfg(feature = "82x")]
     let mut handle = swm.handle;
@@ -61,13 +61,13 @@ fn main() -> ! {
     // perspective from the serial adapter, so this is used the opposite way
 
     #[cfg(feature = "82x")]
-    let tx_pin = p.pins.pio0_7.into_swm_pin();
+    let tx_pin = device.pins.pio0_7.into_swm_pin();
     #[cfg(feature = "82x")]
-    let rx_pin = p.pins.pio0_18.into_swm_pin();
+    let rx_pin = device.pins.pio0_18.into_swm_pin();
     #[cfg(feature = "845")]
-    let tx_pin = p.pins.pio0_25.into_swm_pin();
+    let tx_pin = device.pins.pio0_25.into_swm_pin();
     #[cfg(feature = "845")]
-    let rx_pin = p.pins.pio0_24.into_swm_pin();
+    let rx_pin = device.pins.pio0_24.into_swm_pin();
 
     // Assign U0_RXD & U0_TXD to the rx & tx pins. On the LPCXpresso824-MAX &
     // LPC845-BRK development boards, they're connected to the integrated USB to
@@ -78,7 +78,8 @@ fn main() -> ! {
 
     // Enable USART0
     let mut serial =
-        p.USART0
+        device
+            .USART0
             .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
 
     // Send a string via USART0, blocking until it has been sent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@ use embedded_hal as hal;
 /// should be fully aware of what your code does, and whether that is a valid
 /// use of the hardware.
 #[allow(non_snake_case)]
-pub struct Peripherals {
+pub struct Device {
     /// Pins that can be used for GPIO or other functions
     pub pins: pins::Pins,
 
@@ -395,7 +395,7 @@ pub struct Peripherals {
     pub WWDT: pac::WWDT,
 }
 
-impl Peripherals {
+impl Device {
     /// Take the peripherals safely
     ///
     /// This method can only be called one time to access the peripherals. It
@@ -474,7 +474,7 @@ impl Peripherals {
     }
 
     fn new(p: pac::Peripherals) -> Self {
-        Peripherals {
+        Self {
             pins: pins::Pins::new(),
 
             // HAL peripherals


### PR DESCRIPTION
Based on #214. I could have added this as part of #214, but I figured it might be a more controversial change, and thus worth submitting separately.