### PR TITLE
Re-export `Trait` from `pinint`

### DIFF
--- a/src/pinint.rs
+++ b/src/pinint.rs
@@ -8,4 +8,6 @@ mod interrupt;
 mod peripheral;
 mod traits;
 
-pub use self::{gen::*, interrupt::Interrupt, peripheral::PININT};
+pub use self::{
+    gen::*, interrupt::Interrupt, peripheral::PININT, traits::Trait,
+};


### PR DESCRIPTION
This is required for some use cases, but had been forgotten initially.