### PR TITLE
Clean up clock source code

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -57,4 +57,8 @@ mod clock;
 mod instances;
 mod peripheral;
 
-pub use self::{clock::Clock, instances::Instance, peripheral::I2C};
+pub use self::{
+    clock::{Clock, ClockSource},
+    instances::Instance,
+    peripheral::I2C,
+};

--- a/src/i2c/clock.rs
+++ b/src/i2c/clock.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::syscon::clock_source::PeripheralClockSource;
+use crate::syscon::{self, clock_source::PeripheralClockSelector};
 
 /// A struct containing the clock configuration for a peripheral
 pub struct Clock<Clock> {
@@ -11,16 +11,57 @@ pub struct Clock<Clock> {
 }
 
 /// Implemented for I2C clock sources
-pub trait ClockSource: PeripheralClockSource + private::Sealed {}
+pub trait ClockSource: private::Sealed {
+    /// Select the clock source
+    ///
+    /// This method is used by the I2C API internally. It should not be relevant
+    /// to most users.
+    ///
+    /// The `selector` argument should not be required to implement this trait,
+    /// but it makes sure that the caller has access to the peripheral they are
+    /// selecting the clock for.
+    fn select<S>(selector: &S, handle: &mut syscon::Handle)
+    where
+        S: PeripheralClockSelector;
+}
 
-#[cfg(feature = "845")]
+#[cfg(feature = "82x")]
 mod target {
-    use crate::syscon::clock_source::PeripheralClockSource;
+    use crate::syscon;
 
     use super::ClockSource;
 
-    impl<T> super::private::Sealed for T where T: PeripheralClockSource {}
-    impl<T> ClockSource for T where T: PeripheralClockSource {}
+    impl super::private::Sealed for () {}
+
+    impl ClockSource for () {
+        fn select<S>(_: &S, _: &mut syscon::Handle) {
+            // nothing to do; `()` represents the clock that is selected by
+            // default
+        }
+    }
+}
+
+#[cfg(feature = "845")]
+mod target {
+    use crate::syscon::{
+        self,
+        clock_source::{PeripheralClock, PeripheralClockSelector},
+    };
+
+    use super::ClockSource;
+
+    impl<T> super::private::Sealed for T where T: PeripheralClock {}
+    impl<T> ClockSource for T
+    where
+        T: PeripheralClock,
+    {
+        fn select<S>(selector: &S, handle: &mut syscon::Handle)
+        where
+            S: PeripheralClockSelector,
+        {
+            T::select(selector, handle);
+        }
+    }
 }
 
 mod private {

--- a/src/i2c/clock.rs
+++ b/src/i2c/clock.rs
@@ -1,9 +1,28 @@
 use core::marker::PhantomData;
 
+use crate::syscon::clock_source::PeripheralClockSource;
+
 /// A struct containing the clock configuration for a peripheral
 pub struct Clock<Clock> {
     pub(crate) divval: u16,
     pub(crate) mstsclhigh: u8,
     pub(crate) mstscllow: u8,
     pub(crate) _clock: PhantomData<Clock>,
+}
+
+/// Implemented for I2C clock sources
+pub trait ClockSource: PeripheralClockSource + private::Sealed {}
+
+#[cfg(feature = "845")]
+mod target {
+    use crate::syscon::clock_source::PeripheralClockSource;
+
+    use super::ClockSource;
+
+    impl<T> super::private::Sealed for T where T: PeripheralClockSource {}
+    impl<T> ClockSource for T where T: PeripheralClockSource {}
+}
+
+mod private {
+    pub trait Sealed {}
 }

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -1,12 +1,9 @@
 use embedded_hal::blocking::i2c;
 use void::Void;
 
-use crate::{
-    init_state, swm,
-    syscon::{self, clock_source::PeripheralClock},
-};
+use crate::{init_state, swm, syscon};
 
-use super::{Clock, Instance};
+use super::{Clock, ClockSource, Instance};
 
 /// Interface to an I2C peripheral
 ///
@@ -73,11 +70,12 @@ where
         _: swm::Function<I::Scl, swm::state::Assigned<SclPin>>,
     ) -> I2C<I, init_state::Enabled>
     where
-        Clock<C>: PeripheralClock<I>,
+        C: ClockSource,
     {
         syscon.enable_clock(&mut self.i2c);
 
-        clock.select_clock(syscon);
+        C::select(&self.i2c, syscon);
+
         // We need the I2C mode for the pins set to standard/fast mode,
         // according to the user manual, section 15.3.1. This is already the
         // default value (see user manual, sections 8.5.8 and 8.5.9).

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -59,4 +59,8 @@ mod clock;
 mod instances;
 mod peripheral;
 
-pub use self::{clock::Clock, instances::Instance, peripheral::SPI};
+pub use self::{
+    clock::{Clock, ClockSource},
+    instances::Instance,
+    peripheral::SPI,
+};

--- a/src/spi/clock.rs
+++ b/src/spi/clock.rs
@@ -1,8 +1,27 @@
 use core::marker::PhantomData;
 
+use crate::syscon::clock_source::PeripheralClockSource;
+
 /// A struct containing the clock configuration for a peripheral
 pub struct Clock<Clock> {
     pub(crate) divval: u16,
     // The fields in the DLY register are ignored, since SSEL & EOF aren't used
     pub(crate) _clock: PhantomData<Clock>,
+}
+
+/// Implemented for SPI clock sources
+pub trait ClockSource: PeripheralClockSource + private::Sealed {}
+
+#[cfg(feature = "845")]
+mod target {
+    use crate::syscon::clock_source::PeripheralClockSource;
+
+    use super::ClockSource;
+
+    impl<T> super::private::Sealed for T where T: PeripheralClockSource {}
+    impl<T> ClockSource for T where T: PeripheralClockSource {}
+}
+
+mod private {
+    pub trait Sealed {}
 }

--- a/src/spi/clock.rs
+++ b/src/spi/clock.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::syscon::clock_source::PeripheralClockSource;
+use crate::syscon::{self, clock_source::PeripheralClockSelector};
 
 /// A struct containing the clock configuration for a peripheral
 pub struct Clock<Clock> {
@@ -10,16 +10,57 @@ pub struct Clock<Clock> {
 }
 
 /// Implemented for SPI clock sources
-pub trait ClockSource: PeripheralClockSource + private::Sealed {}
+pub trait ClockSource: private::Sealed {
+    /// Select the clock source
+    ///
+    /// This method is used by the SPI API internally. It should not be relevant
+    /// to most users.
+    ///
+    /// The `selector` argument should not be required to implement this trait,
+    /// but it makes sure that the caller has access to the peripheral they are
+    /// selecting the clock for.
+    fn select<S>(selector: &S, handle: &mut syscon::Handle)
+    where
+        S: PeripheralClockSelector;
+}
 
-#[cfg(feature = "845")]
+#[cfg(feature = "82x")]
 mod target {
-    use crate::syscon::clock_source::PeripheralClockSource;
+    use crate::syscon;
 
     use super::ClockSource;
 
-    impl<T> super::private::Sealed for T where T: PeripheralClockSource {}
-    impl<T> ClockSource for T where T: PeripheralClockSource {}
+    impl super::private::Sealed for () {}
+
+    impl ClockSource for () {
+        fn select<S>(_: &S, _: &mut syscon::Handle) {
+            // nothing to do; `()` represents the clock that is selected by
+            // default
+        }
+    }
+}
+
+#[cfg(feature = "845")]
+mod target {
+    use crate::syscon::{
+        self,
+        clock_source::{PeripheralClock, PeripheralClockSelector},
+    };
+
+    use super::ClockSource;
+
+    impl<T> super::private::Sealed for T where T: PeripheralClock {}
+    impl<T> ClockSource for T
+    where
+        T: PeripheralClock,
+    {
+        fn select<S>(selector: &S, handle: &mut syscon::Handle)
+        where
+            S: PeripheralClockSelector,
+        {
+            T::select(selector, handle);
+        }
+    }
 }
 
 mod private {

--- a/src/spi/peripheral.rs
+++ b/src/spi/peripheral.rs
@@ -3,10 +3,10 @@ use embedded_hal::spi::{FullDuplex, Mode, Phase, Polarity};
 use crate::{
     init_state, pins,
     swm::{self, FunctionTrait},
-    syscon::{self, clock_source::PeripheralClock},
+    syscon,
 };
 
-use super::{Clock, Instance};
+use super::{Clock, ClockSource, Instance};
 
 /// Interface to a SPI peripheral
 ///
@@ -75,11 +75,11 @@ where
         I::Sck: FunctionTrait<SckPin>,
         I::Mosi: FunctionTrait<MosiPin>,
         I::Miso: FunctionTrait<MisoPin>,
-        Clock<CLOCK>: PeripheralClock<I>,
+        CLOCK: ClockSource,
     {
         syscon.enable_clock(&self.spi);
 
-        clock.select_clock(syscon);
+        CLOCK::select(&self.spi, syscon);
 
         self.spi
             .div

--- a/src/syscon/clock_source.rs
+++ b/src/syscon/clock_source.rs
@@ -12,27 +12,26 @@ pub use clocksource_845::*;
 
 use crate::syscon;
 
-/// Internal trait used configure clocking of peripheals
+/// Internal trait used configure peripheral clock sources
 ///
 /// This trait is an internal implementation detail and should neither be
 /// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
 /// be considered breaking changes.
-pub trait PeripheralClock<PERIPH> {
-    /// Selects the clock
-    fn select_clock(&self, handle: &mut syscon::Handle);
-}
-
-/// Internal trait used for defining valid peripheal clock sources
-///
-/// This trait is an internal implementation detail and should neither be
-/// implemented nor used outside of LPC8xx HAL. Any changes to this trait won't
-/// be considered breaking changes.
-pub trait PeripheralClockSource {
+pub trait PeripheralClock {
     /// The variant of FCLKSEL.SEL that selects this clock source
     ///
     /// This is not available (or required) on LPC82x.
     #[cfg(feature = "845")]
     const CLOCK: crate::pac::syscon::fclksel::SEL_A;
+
+    /// Select the clock
+    ///
+    /// The `selector` argument should not be required to implement this trait,
+    /// but it makes sure that the caller has access to the peripheral they are
+    /// selecting the clock for.
+    fn select<S>(selector: &S, handle: &mut syscon::Handle)
+    where
+        S: PeripheralClockSelector;
 }
 
 /// Internal trait used for defining the fclksel index for a peripheral

--- a/src/syscon/clock_source/clocksource_82x.rs
+++ b/src/syscon/clock_source/clocksource_82x.rs
@@ -1,8 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::{i2c, spi, syscon};
-
-use super::PeripheralClock;
+use crate::{i2c, spi};
 
 impl i2c::Clock<()> {
     /// Create the clock config for the i2c peripheral
@@ -32,12 +30,6 @@ impl i2c::Clock<()> {
     }
 }
 
-impl<PERIPH: crate::i2c::Instance> PeripheralClock<PERIPH> for i2c::Clock<()> {
-    fn select_clock(&self, _: &mut syscon::Handle) {
-        // NOOP, selected by default
-    }
-}
-
 impl spi::Clock<()> {
     /// Create the clock config for the spi peripheral
     pub fn new(divval: u16) -> Self {
@@ -45,11 +37,5 @@ impl spi::Clock<()> {
             divval,
             _clock: PhantomData,
         }
-    }
-}
-
-impl<PERIPH: crate::spi::Instance> PeripheralClock<PERIPH> for spi::Clock<()> {
-    fn select_clock(&self, _: &mut syscon::Handle) {
-        // NOOP, selected by default
     }
 }

--- a/src/syscon/clock_source/clocksource_82x.rs
+++ b/src/syscon/clock_source/clocksource_82x.rs
@@ -1,13 +1,8 @@
 use core::marker::PhantomData;
 
-use crate::{
-    i2c, spi,
-    syscon::{self, UARTFRG},
-};
+use crate::{i2c, spi, syscon};
 
-use super::{PeripheralClock, PeripheralClockSource};
-
-impl PeripheralClockSource for UARTFRG {}
+use super::PeripheralClock;
 
 impl i2c::Clock<()> {
     /// Create the clock config for the i2c peripheral

--- a/src/syscon/clock_source/clocksource_845.rs
+++ b/src/syscon/clock_source/clocksource_845.rs
@@ -21,7 +21,7 @@ impl PeripheralClockSource for IOSC {
     const CLOCK: SEL_A = SEL_A::FRO;
 }
 
-impl<CLOCK: PeripheralClockSource> i2c::Clock<CLOCK> {
+impl<CLOCK: i2c::ClockSource> i2c::Clock<CLOCK> {
     /// Create the clock config for the i2c peripheral
     ///
     /// mstclhigh & mstcllow have to be between 2-9
@@ -51,8 +51,8 @@ impl i2c::Clock<IOSC> {
     }
 }
 
-impl<PERIPH: i2c::Instance, CLOCK: PeripheralClockSource>
-    PeripheralClock<PERIPH> for i2c::Clock<CLOCK>
+impl<PERIPH: i2c::Instance, CLOCK: i2c::ClockSource> PeripheralClock<PERIPH>
+    for i2c::Clock<CLOCK>
 {
     fn select_clock(&self, syscon: &mut syscon::Handle) {
         syscon.fclksel[PERIPH::REGISTER_NUM]
@@ -60,7 +60,7 @@ impl<PERIPH: i2c::Instance, CLOCK: PeripheralClockSource>
     }
 }
 
-impl<CLOCK: PeripheralClockSource> spi::Clock<CLOCK> {
+impl<CLOCK: spi::ClockSource> spi::Clock<CLOCK> {
     /// Create the clock config for the spi peripheral
     pub fn new(_: &CLOCK, divval: u16) -> Self {
         Self {
@@ -70,8 +70,8 @@ impl<CLOCK: PeripheralClockSource> spi::Clock<CLOCK> {
     }
 }
 
-impl<PERIPH: spi::Instance, CLOCK: PeripheralClockSource>
-    PeripheralClock<PERIPH> for spi::Clock<CLOCK>
+impl<PERIPH: spi::Instance, CLOCK: spi::ClockSource> PeripheralClock<PERIPH>
+    for spi::Clock<CLOCK>
 {
     fn select_clock(&self, syscon: &mut syscon::Handle) {
         syscon.fclksel[PERIPH::REGISTER_NUM]

--- a/src/usart.rs
+++ b/src/usart.rs
@@ -74,7 +74,7 @@ mod rx;
 mod tx;
 
 pub use self::{
-    clock::Clock,
+    clock::{Clock, ClockSource},
     instances::Instance,
     peripheral::USART,
     rx::{Error, Rx},

--- a/src/usart/clock.rs
+++ b/src/usart/clock.rs
@@ -34,7 +34,7 @@ where
 }
 
 #[cfg(feature = "82x")]
-impl<I> PeripheralClock<I> for Clock<crate::syscon::UARTFRG>
+impl<I> PeripheralClock<I> for Clock<syscon::UARTFRG>
 where
     I: Instance,
 {
@@ -44,7 +44,7 @@ where
 }
 
 #[cfg(feature = "845")]
-impl Clock<crate::syscon::IOSC> {
+impl Clock<syscon::IOSC> {
     /// Create a new configuration with a specified baudrate
     ///
     /// Assumes the internal oscillator runs at 12 MHz

--- a/src/usart/clock.rs
+++ b/src/usart/clock.rs
@@ -31,7 +31,11 @@ where
 #[cfg(feature = "82x")]
 mod target {
     use crate::{
-        syscon::{self, clock_source::PeripheralClock},
+        syscon::{
+            self,
+            clock_source::{PeripheralClock, PeripheralClockSource},
+            UARTFRG,
+        },
         usart::Instance,
     };
 
@@ -45,6 +49,8 @@ mod target {
             // NOOP, selected by default
         }
     }
+
+    impl PeripheralClockSource for UARTFRG {}
 }
 
 #[cfg(feature = "845")]

--- a/src/usart/clock.rs
+++ b/src/usart/clock.rs
@@ -41,7 +41,7 @@ mod target {
 
     use super::Clock;
 
-    impl<I> PeripheralClock<I> for Clock<syscon::UARTFRG>
+    impl<I> PeripheralClock<I> for Clock<UARTFRG>
     where
         I: Instance,
     {

--- a/src/usart/clock.rs
+++ b/src/usart/clock.rs
@@ -1,11 +1,6 @@
 use core::marker::PhantomData;
 
-use crate::syscon::{
-    self,
-    clock_source::{PeripheralClock, PeripheralClockSource},
-};
-
-use super::instances::Instance;
+use crate::syscon::clock_source::PeripheralClockSource;
 
 /// Defines the clock configuration for a USART instance
 pub struct Clock<Clock> {
@@ -34,46 +29,69 @@ where
 }
 
 #[cfg(feature = "82x")]
-impl<I> PeripheralClock<I> for Clock<syscon::UARTFRG>
-where
-    I: Instance,
-{
-    fn select_clock(&self, _: &mut syscon::Handle) {
-        // NOOP, selected by default
+mod target {
+    use crate::{
+        syscon::{self, clock_source::PeripheralClock},
+        usart::Instance,
+    };
+
+    use super::Clock;
+
+    impl<I> PeripheralClock<I> for Clock<syscon::UARTFRG>
+    where
+        I: Instance,
+    {
+        fn select_clock(&self, _: &mut syscon::Handle) {
+            // NOOP, selected by default
+        }
     }
 }
 
 #[cfg(feature = "845")]
-impl Clock<syscon::IOSC> {
-    /// Create a new configuration with a specified baudrate
-    ///
-    /// Assumes the internal oscillator runs at 12 MHz
-    pub fn new_with_baudrate(baudrate: u32) -> Self {
-        // We want something with 5% tolerance
-        let calc = baudrate * 20;
-        let mut osrval = 5;
-        for i in (5..=16).rev() {
-            if calc * (i as u32) < 12_000_000 {
-                osrval = i;
+mod target {
+    use core::marker::PhantomData;
+
+    use crate::{
+        syscon::{
+            self,
+            clock_source::{PeripheralClock, PeripheralClockSource},
+        },
+        usart::Instance,
+    };
+
+    use super::Clock;
+
+    impl Clock<syscon::IOSC> {
+        /// Create a new configuration with a specified baudrate
+        ///
+        /// Assumes the internal oscillator runs at 12 MHz
+        pub fn new_with_baudrate(baudrate: u32) -> Self {
+            // We want something with 5% tolerance
+            let calc = baudrate * 20;
+            let mut osrval = 5;
+            for i in (5..=16).rev() {
+                if calc * (i as u32) < 12_000_000 {
+                    osrval = i;
+                }
+            }
+            let psc = (12_000_000 / (baudrate * osrval as u32) - 1) as u16;
+            let osrval = osrval - 1;
+            Self {
+                psc,
+                osrval,
+                _clock: PhantomData,
             }
         }
-        let psc = (12_000_000 / (baudrate * osrval as u32) - 1) as u16;
-        let osrval = osrval - 1;
-        Self {
-            psc,
-            osrval,
-            _clock: PhantomData,
-        }
     }
-}
 
-#[cfg(feature = "845")]
-impl<I, C> PeripheralClock<I> for Clock<C>
-where
-    I: Instance,
-    C: PeripheralClockSource,
-{
-    fn select_clock(&self, syscon: &mut syscon::Handle) {
-        syscon.fclksel[I::REGISTER_NUM].write(|w| w.sel().variant(C::CLOCK));
+    impl<I, C> PeripheralClock<I> for Clock<C>
+    where
+        I: Instance,
+        C: PeripheralClockSource,
+    {
+        fn select_clock(&self, syscon: &mut syscon::Handle) {
+            syscon.fclksel[I::REGISTER_NUM]
+                .write(|w| w.sel().variant(C::CLOCK));
+        }
     }
 }

--- a/src/usart/peripheral.rs
+++ b/src/usart/peripheral.rs
@@ -11,11 +11,11 @@ use crate::{
     pac::NVIC,
     pins,
     swm::{self, FunctionTrait},
-    syscon::{self, clock_source::PeripheralClock},
+    syscon,
 };
 
 use super::{
-    clock::Clock,
+    clock::{Clock, ClockSource},
     instances::Instance,
     rx::{Error, Rx},
     tx::Tx,
@@ -103,11 +103,11 @@ where
         TxPin: pins::Trait,
         I::Rx: FunctionTrait<RxPin>,
         I::Tx: FunctionTrait<TxPin>,
-        Clock<CLOCK>: PeripheralClock<I>,
+        CLOCK: ClockSource,
     {
         syscon.enable_clock(&self.usart);
 
-        clock.select_clock(syscon);
+        CLOCK::select(&self.usart, syscon);
         self.usart
             .brg
             .write(|w| unsafe { w.brgval().bits(clock.psc) });


### PR DESCRIPTION
Details in the commits. This enables some further clean-ups in the I2C and SPI clock source code.