### PR TITLE
Prepare I2C module for adding slave mode

### DIFF
--- a/examples/i2c_eeprom.rs
+++ b/examples/i2c_eeprom.rs
@@ -78,7 +78,7 @@ fn main() -> ! {
 
     let i2c_clock = i2c::Clock::new_400khz();
     let mut i2c =
-        i2c.enable(&i2c_clock, &mut syscon.handle, i2c0_sda, i2c0_scl);
+        i2c.enable_master(&i2c_clock, &mut syscon.handle, i2c0_sda, i2c0_scl);
 
     // Address of the eeprom
     // ADJUST THIS

--- a/examples/i2c_vl53l0x.rs
+++ b/examples/i2c_vl53l0x.rs
@@ -83,7 +83,7 @@ fn main() -> ! {
 
     let i2c_clock = i2c::Clock::new_400khz();
     let mut i2c =
-        i2c.enable(&i2c_clock, &mut syscon.handle, i2c0_sda, i2c0_scl);
+        i2c.enable_master(&i2c_clock, &mut syscon.handle, i2c0_sda, i2c0_scl);
 
     serial
         .bwrite_all(b"Writing data...\n")

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -38,7 +38,7 @@
 //!     &mut swm_handle,
 //! );
 //!
-//! let mut i2c = p.I2C0.enable(
+//! let mut i2c = p.I2C0.enable_master(
 //!     &i2c::Clock::new_400khz(),
 //!     &mut syscon.handle,
 //!     i2c0_sda,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -54,13 +54,15 @@
 //! [examples in the repository]: https://github.com/lpc-rs/lpc8xx-hal/tree/master/examples
 
 mod clock;
+mod error;
 mod instances;
 mod interrupts;
 mod peripheral;
 
 pub use self::{
     clock::{Clock, ClockSource},
+    error::Error,
     instances::Instance,
     interrupts::Interrupts,
-    peripheral::{Error, Master, Slave, I2C},
+    peripheral::{Master, Slave, I2C},
 };

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -62,5 +62,5 @@ pub use self::{
     clock::{Clock, ClockSource},
     instances::Instance,
     interrupts::Interrupts,
-    peripheral::{Error, I2C},
+    peripheral::{Error, Master, Slave, I2C},
 };

--- a/src/i2c/error.rs
+++ b/src/i2c/error.rs
@@ -1,0 +1,60 @@
+use super::Instance;
+
+/// I2C error
+#[derive(Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Event Timeout
+    ///
+    /// Corresponds to the EVENTTIMEOUT flag in the STAT register.
+    EventTimeout,
+
+    /// Master Arbitration Loss
+    ///
+    /// Corresponds to the MSTARBLOSS flag in the STAT register.
+    MasterArbitrationLoss,
+
+    /// Master Start/Stop Error
+    ///
+    /// Corresponds to the MSTSTSTPERR flag in the STAT register.
+    MasterStartStopError,
+
+    /// Monitor Overflow
+    ///
+    /// Corresponds to the MONOV flag in the STAT register.
+    MonitorOverflow,
+
+    /// SCL Timeout
+    ///
+    /// Corresponds to the SCLTIMEOUT flag in the STAT register.
+    SclTimeout,
+}
+
+impl Error {
+    pub(super) fn read<I: Instance>(i2c: &I) -> Option<Self> {
+        let stat = i2c.stat.read();
+
+        // Check for error flags. If one is set, clear it and return the error.
+        if stat.mstarbloss().bit_is_set() {
+            i2c.stat.write(|w| w.mstarbloss().set_bit());
+            return Some(Self::MasterArbitrationLoss);
+        }
+        if stat.mstststperr().bit_is_set() {
+            i2c.stat.write(|w| w.mstststperr().set_bit());
+            return Some(Self::MasterStartStopError);
+        }
+        if stat.monov().bit_is_set() {
+            i2c.stat.write(|w| w.monov().set_bit());
+            return Some(Self::MonitorOverflow);
+        }
+        if stat.eventtimeout().bit_is_set() {
+            i2c.stat.write(|w| w.eventtimeout().set_bit());
+            return Some(Self::EventTimeout);
+        }
+        if stat.scltimeout().bit_is_set() {
+            i2c.stat.write(|w| w.scltimeout().set_bit());
+            return Some(Self::SclTimeout);
+        }
+
+        None
+    }
+}

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -40,7 +40,7 @@ where
         }
     }
 
-    /// Enable the I2C peripheral
+    /// Enable the I2C peripheral in master mode
     ///
     /// This method is only available, if `I2C` is in the [`Disabled`] state.
     /// Code that attempts to call this method when the peripheral is already

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -61,7 +61,7 @@ where
     ///
     /// [`Disabled`]: ../init_state/struct.Disabled.html
     /// [`Enabled`]: ../init_state/struct.Enabled.html
-    pub fn enable<SdaPin, SclPin, C>(
+    pub fn enable_master<SdaPin, SclPin, C>(
         mut self,
         clock: &Clock<C>,
         syscon: &mut syscon::Handle,

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -2,7 +2,7 @@ use embedded_hal::blocking::i2c;
 
 use crate::{init_state, swm, syscon};
 
-use super::{Clock, ClockSource, Instance, Interrupts};
+use super::{Clock, ClockSource, Error, Instance, Interrupts};
 
 /// Interface to an I2C peripheral
 ///
@@ -267,62 +267,3 @@ pub struct Master;
 ///
 /// [`I2C`]: struct.I2C.html
 pub struct Slave;
-
-/// I2C error
-#[derive(Debug, Eq, PartialEq)]
-pub enum Error {
-    /// Event Timeout
-    ///
-    /// Corresponds to the EVENTTIMEOUT flag in the STAT register.
-    EventTimeout,
-
-    /// Master Arbitration Loss
-    ///
-    /// Corresponds to the MSTARBLOSS flag in the STAT register.
-    MasterArbitrationLoss,
-
-    /// Master Start/Stop Error
-    ///
-    /// Corresponds to the MSTSTSTPERR flag in the STAT register.
-    MasterStartStopError,
-
-    /// Monitor Overflow
-    ///
-    /// Corresponds to the MONOV flag in the STAT register.
-    MonitorOverflow,
-
-    /// SCL Timeout
-    ///
-    /// Corresponds to the SCLTIMEOUT flag in the STAT register.
-    SclTimeout,
-}
-
-impl Error {
-    fn read<I: Instance>(i2c: &I) -> Option<Self> {
-        let stat = i2c.stat.read();
-
-        // Check for error flags. If one is set, clear it and return the error.
-        if stat.mstarbloss().bit_is_set() {
-            i2c.stat.write(|w| w.mstarbloss().set_bit());
-            return Some(Self::MasterArbitrationLoss);
-        }
-        if stat.mstststperr().bit_is_set() {
-            i2c.stat.write(|w| w.mstststperr().set_bit());
-            return Some(Self::MasterStartStopError);
-        }
-        if stat.monov().bit_is_set() {
-            i2c.stat.write(|w| w.monov().set_bit());
-            return Some(Self::MonitorOverflow);
-        }
-        if stat.eventtimeout().bit_is_set() {
-            i2c.stat.write(|w| w.eventtimeout().set_bit());
-            return Some(Self::EventTimeout);
-        }
-        if stat.scltimeout().bit_is_set() {
-            i2c.stat.write(|w| w.scltimeout().set_bit());
-            return Some(Self::SclTimeout);
-        }
-
-        None
-    }
-}

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -258,6 +258,16 @@ where
     }
 }
 
+/// Used as a type parameter by [`I2C`] to indicate master mode
+///
+/// [`I2C`]: struct.I2C.html
+pub struct Master;
+
+/// Used as a type parameter by [`I2C`] to indicate slave mode
+///
+/// [`I2C`]: struct.I2C.html
+pub struct Slave;
+
 /// I2C error
 #[derive(Debug, Eq, PartialEq)]
 pub enum Error {

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -24,7 +24,7 @@ use super::{Clock, ClockSource, Instance, Interrupts};
 /// [`embedded_hal::blocking::i2c::Read`]: #impl-Read
 /// [`embedded_hal::blocking::i2c::Write`]: #impl-Write
 /// [module documentation]: index.html
-pub struct I2C<I, State = init_state::Enabled> {
+pub struct I2C<I, State> {
     i2c: I,
     _state: State,
 }

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -67,7 +67,7 @@ where
         syscon: &mut syscon::Handle,
         _: swm::Function<I::Sda, swm::state::Assigned<SdaPin>>,
         _: swm::Function<I::Scl, swm::state::Assigned<SclPin>>,
-    ) -> I2C<I, init_state::Enabled>
+    ) -> I2C<I, init_state::Enabled<Master>>
     where
         C: ClockSource,
     {
@@ -94,12 +94,12 @@ where
 
         I2C {
             i2c: self.i2c,
-            _state: init_state::Enabled(()),
+            _state: init_state::Enabled(Master),
         }
     }
 }
 
-impl<I> I2C<I, init_state::Enabled>
+impl<I, Mode> I2C<I, init_state::Enabled<Mode>>
 where
     I: Instance,
 {
@@ -153,7 +153,7 @@ where
     }
 }
 
-impl<I> i2c::Write for I2C<I, init_state::Enabled>
+impl<I> i2c::Write for I2C<I, init_state::Enabled<Master>>
 where
     I: Instance,
 {
@@ -205,7 +205,7 @@ where
     }
 }
 
-impl<I> i2c::Read for I2C<I, init_state::Enabled>
+impl<I> i2c::Read for I2C<I, init_state::Enabled<Master>>
 where
     I: Instance,
 {


### PR DESCRIPTION
I'm currently working on I2C slave mode. Since that might still take a bit more time (it's currently not working) and since it looks like I might be adding more error handling code on the master side to debug it, I figured I'd submit this now, to at least get some of it reviewed, and to keep any merging and rebasing on my side to a minimum.