### PR TITLE
Migrate from RTFM to RTIC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ version      = "0.3.0"
 
 [dev-dependencies]
 panic-halt    = "0.2.0"
-cortex-m-rtfm = "0.5.1"
+cortex-m-rtic = "0.5.3"
 
 
 # Termion has been made optional, as it doesn't build on Windows:

--- a/examples/pinint.rs
+++ b/examples/pinint.rs
@@ -12,7 +12,7 @@ use lpc8xx_hal::{
 use panic_halt as _;
 use void::ResultVoidExt;
 
-#[rtfm::app(device = lpc8xx_hal::pac)]
+#[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {
     struct Resources {
         int: pinint::Interrupt<PININT0, PIO0_4, Enabled>,

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -10,7 +10,7 @@ use lpc8xx_hal::{
 };
 use panic_halt as _;
 
-#[rtfm::app(device = lpc8xx_hal::pac)]
+#[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {
     struct Resources {
         delay: Delay,


### PR DESCRIPTION
The RTFM framework has been renamed to RTIC. Everything else should be
the same, so this change should basically be a no-op.