### PR TITLE
Avoid spurious CI failures by only installing rustfmt when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 
 install:
   - rustup target add thumbv6m-none-eabi
-  - rustup component add rustfmt
 
 script:
   - ./scripts/build.sh

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -14,6 +14,8 @@ export RUSTFLAGS="-D warnings"
 
 # Check for formatting with the stable rustfmt
 if [ "$TRAVIS_RUST_VERSION" != beta ] && [ "$TRAVIS_RUST_VERSION" != nightly ]; then
+    # Only install rustup on stable, since it's not needed otherwise (and sometimes unavailable)
+    rustup component add rustfmt
     cargo fmt -- --check
 fi
 


### PR DESCRIPTION
This is pretty annoying, see https://github.com/lpc-rs/lpc8xx-hal/pull/244#issuecomment-646547406