### PR TITLE
Fix `embedded-hal` version of `set_low`

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -440,7 +440,7 @@ where
 
     fn set_low(&mut self) -> Result<(), Self::Error> {
         // Call the inherent method defined above.
-        Ok(self.set_high())
+        Ok(self.set_low())
     }
 }
 


### PR DESCRIPTION
This is a pretty bad bug. I suggest we publish a patch release after merging this.