### PR TITLE
Add more infallible GPIO methods

### DIFF
--- a/examples/pinint.rs
+++ b/examples/pinint.rs
@@ -6,11 +6,9 @@ use lpc8xx_hal::{
     init_state::Enabled,
     pinint::{self, PININT0},
     pins::{PIO0_4, PIO1_1},
-    prelude::*,
     Peripherals,
 };
 use panic_halt as _;
-use void::ResultVoidExt;
 
 #[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {
@@ -48,7 +46,7 @@ const APP: () = {
         let int = context.resources.int;
         let led = context.resources.led;
 
-        led.toggle().void_unwrap();
+        led.toggle();
 
         int.clear_rising_edge_flag();
         int.clear_falling_edge_flag();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -460,8 +460,7 @@ where
     /// [`into_gpio_pin`]: #method.into_gpio_pin
     /// [`into_output`]: #method.into_output
     fn is_set_high(&self) -> Result<bool, Self::Error> {
-        // This is sound, as we only do a stateless write to a bit that no other
-        // `GpioPin` instance writes to.
+        // This is sound, as we only read a bit from a register.
         let gpio = unsafe { &*pac::GPIO::ptr() };
         let registers = Registers::new(gpio);
 
@@ -480,8 +479,7 @@ where
     /// [`into_gpio_pin`]: #method.into_gpio_pin
     /// [`into_output`]: #method.into_output
     fn is_set_low(&self) -> Result<bool, Self::Error> {
-        // This is sound, as we only do a stateless write to a bit that no other
-        // `GpioPin` instance writes to.
+        // This is sound, as we only read a bit from a register.
         let gpio = unsafe { &*pac::GPIO::ptr() };
         let registers = Registers::new(gpio);
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -440,11 +440,7 @@ where
     /// [`into_gpio_pin`]: #method.into_gpio_pin
     /// [`into_output`]: #method.into_output
     pub fn is_set_low(&self) -> bool {
-        // This is sound, as we only read a bit from a register.
-        let gpio = unsafe { &*pac::GPIO::ptr() };
-        let registers = Registers::new(gpio);
-
-        !registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+        !self.is_set_high()
     }
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -44,7 +44,7 @@
 use core::marker::PhantomData;
 
 use embedded_hal::digital::v2::{
-    toggleable, InputPin, OutputPin, StatefulOutputPin,
+    InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin,
 };
 use void::Void;
 
@@ -514,9 +514,16 @@ where
     }
 }
 
-impl<T> toggleable::Default for GpioPin<T, direction::Output> where
-    T: pins::Trait
+impl<T> ToggleableOutputPin for GpioPin<T, direction::Output>
+where
+    T: pins::Trait,
 {
+    type Error = Void;
+
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        // Call the inherent method defined above.
+        Ok(self.toggle())
+    }
 }
 
 /// The voltage level of a pin

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -408,6 +408,44 @@ where
 
         set_low::<T>(&registers);
     }
+
+    /// Indicates whether the pin output is currently set to HIGH
+    ///
+    /// This method is only available, if two conditions are met:
+    /// - The pin is in the GPIO state. Use [`into_gpio_pin`] to achieve this.
+    /// - The pin direction is set to output. See [`into_output`].
+    ///
+    /// Unless both of these conditions are met, code trying to call this method
+    /// will not compile.
+    ///
+    /// [`into_gpio_pin`]: #method.into_gpio_pin
+    /// [`into_output`]: #method.into_output
+    pub fn is_set_high(&self) -> bool {
+        // This is sound, as we only read a bit from a register.
+        let gpio = unsafe { &*pac::GPIO::ptr() };
+        let registers = Registers::new(gpio);
+
+        registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+    }
+
+    /// Indicates whether the pin output is currently set to LOW
+    ///
+    /// This method is only available, if two conditions are met:
+    /// - The pin is in the GPIO state. Use [`into_gpio_pin`] to achieve this.
+    /// - The pin direction is set to output. See [`into_output`].
+    ///
+    /// Unless both of these conditions are met, code trying to call this method
+    /// will not compile.
+    ///
+    /// [`into_gpio_pin`]: #method.into_gpio_pin
+    /// [`into_output`]: #method.into_output
+    pub fn is_set_low(&self) -> bool {
+        // This is sound, as we only read a bit from a register.
+        let gpio = unsafe { &*pac::GPIO::ptr() };
+        let registers = Registers::new(gpio);
+
+        !registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK
+    }
 }
 
 impl<T> InputPin for GpioPin<T, direction::Input>
@@ -448,42 +486,14 @@ impl<T> StatefulOutputPin for GpioPin<T, direction::Output>
 where
     T: pins::Trait,
 {
-    /// Indicates whether the pin output is currently set to HIGH
-    ///
-    /// This method is only available, if two conditions are met:
-    /// - The pin is in the GPIO state. Use [`into_gpio_pin`] to achieve this.
-    /// - The pin direction is set to output. See [`into_output`].
-    ///
-    /// Unless both of these conditions are met, code trying to call this method
-    /// will not compile.
-    ///
-    /// [`into_gpio_pin`]: #method.into_gpio_pin
-    /// [`into_output`]: #method.into_output
     fn is_set_high(&self) -> Result<bool, Self::Error> {
-        // This is sound, as we only read a bit from a register.
-        let gpio = unsafe { &*pac::GPIO::ptr() };
-        let registers = Registers::new(gpio);
-
-        Ok(registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK)
+        // Call the inherent method defined above.
+        Ok(self.is_set_high())
     }
 
-    /// Indicates whether the pin output is currently set to LOW
-    ///
-    /// This method is only available, if two conditions are met:
-    /// - The pin is in the GPIO state. Use [`into_gpio_pin`] to achieve this.
-    /// - The pin direction is set to output. See [`into_output`].
-    ///
-    /// Unless both of these conditions are met, code trying to call this method
-    /// will not compile.
-    ///
-    /// [`into_gpio_pin`]: #method.into_gpio_pin
-    /// [`into_output`]: #method.into_output
     fn is_set_low(&self) -> Result<bool, Self::Error> {
-        // This is sound, as we only read a bit from a register.
-        let gpio = unsafe { &*pac::GPIO::ptr() };
-        let registers = Registers::new(gpio);
-
-        Ok(!registers.pin[T::PORT].read().port().bits() & T::MASK == T::MASK)
+        // Call the inherent method defined above.
+        Ok(self.is_set_low())
     }
 }
 


### PR DESCRIPTION
This continues the work done in #242.

This is based on #246. Until that's merged, I'm leaving this as a draft.