### PR TITLE
Release version 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="v0.7.1"></a>
+## v0.7.1 (2020-06-26)
+
+- Fix `embedded-hal` version of `set_low` ([#246])
+- Add more infallible GPIO methods ([#247])
+
+[#246]: https://github.com/lpc-rs/lpc8xx-hal/pull/246
+[#247]: https://github.com/lpc-rs/lpc8xx-hal/pull/247
+
 
 <a name="v0.7.0"></a>
 ## v0.7.0 (2020-06-22)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "lpc8xx-hal"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 
 authors = [


### PR DESCRIPTION
I've decided to also include #247 in this release. I figured it doesn't matter much one way or the other, but not including it would have meant I might have missed it in the changelog for the next release, as GitHub orders merged PRs by date opened, not date merged.

What needs to be done now:
- @david-sawatzke:
  - [x] Review/merge #247
  - [x] Review/approve this pull request
- @hannobraun:
  - [x] Rebase after #247 has been merged
  - [x] Update date in changelog, if necessary
  - [x] Publish on crates.io
  - [ ] Merge this pull request
  - [ ] Create and push release tag