### PR TITLE
Add configuration for cargo-embed; switch examples to use `panic-rtt-target`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,15 @@ version      = "0.3.0"
 
 
 [dev-dependencies]
-panic-halt    = "0.2.0"
 cortex-m-rtic = "0.5.3"
+
+[dev-dependencies.panic-rtt-target]
+version  = "0.1.0"
+features = ["cortex-m"]
+
+[dev-dependencies.rtt-target]
+version  = "0.2.0"
+features = ["cortex-m"]
 
 
 # Termion has been made optional, as it doesn't build on Windows:

--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,28 @@
+# Common configuration. The target-specific configurations below interit from
+# this implicitly.
+
+[default.rtt]
+enabled = false
+
+
+# Configuration for LPCXpresso824-MAX development board.
+
+[lpc82x.probe]
+usb_vid = "0d28"
+usb_pid = "0204"
+
+[lpc82x.general]
+# The schematics say the chip on the board is an "LPC824M201FHI33", but I'm
+# guessing this is a typo, and in any case, the following is probably close
+# enough.
+chip = "LPC824M201JHI33"
+
+
+# Configuration for the LPC845-BRK development board.
+
+[lpc845.probe]
+usb_vid = "1fc9"
+usb_pid = "0132"
+
+[lpc845.general]
+chip = "LPC845M301JHI48"

--- a/Embed.toml
+++ b/Embed.toml
@@ -2,7 +2,7 @@
 # this implicitly.
 
 [default.rtt]
-enabled = false
+enabled = true
 
 
 # Configuration for LPCXpresso824-MAX development board.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ For functionality that is not yet covered by this crate, you may need to fall ba
 
 The authoritative source on the supported MCUs are their respective user manuals, available from NXP.
 
-[lpc82x-pac]: https://crates.io/crates/lpc82x-pac
-[lpc845-pac]: https://crates.io/crates/lpc84x-pac
+[API Reference]: https://docs.rs/lpc8xx-hal
+[`lpc82x-pac`]: https://crates.io/crates/lpc82x-pac
+[`lpc845-pac`]: https://crates.io/crates/lpc845-pac
 
 
 ## Help Wanted

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ lpc8xx-hal = "0.7"
 
 If you want to use LPC8xx HAL in an application (as opposed to a library), there are additional things that need to be set up. Please refer to the [API Reference] for details.
 
+To run one of the examples from this repository, please adapt the following command if you're using an LPC845-BRK board:
+```
+cargo embed lpc845 --example gpio_delay --features 845-rt
+```
+
+Or adapt the following command if using an LPCXpresso824-MAX board:
+```
+cargo embed lpc82c --example gpio_delay --features 82x-rt
+```
+
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cargo embed lpc845 --example gpio_delay --features 845-rt
 
 Or adapt the following command if using an LPCXpresso824-MAX board:
 ```
-cargo embed lpc82c --example gpio_delay --features 82x-rt
+cargo embed lpc82x --example gpio_delay --features 82x-rt
 ```
 
 

--- a/examples/adc.rs
+++ b/examples/adc.rs
@@ -3,7 +3,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use core::fmt::Write;
 use nb::block;
@@ -15,6 +15,8 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 

--- a/examples/ctimer_fade.rs
+++ b/examples/ctimer_fade.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{
     cortex_m_rt::entry, delay::Delay, prelude::*, CorePeripherals, Peripherals,
@@ -9,6 +9,8 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     // Get access to the device's peripherals. Since only one instance of this
     // struct can exist, the call to `take` returns an `Option<Peripherals>`.
     // If we tried to call the method a second time, it would return `None`, but

--- a/examples/gpio_delay.rs
+++ b/examples/gpio_delay.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{
     cortex_m_rt::entry, delay::Delay, gpio::Level, prelude::*, CorePeripherals,
@@ -10,6 +10,8 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     // Get access to the device's peripherals. Since only one instance of this
     // struct can exist, the call to `take` returns an `Option<Peripherals>`.
     // If we tried to call the method a second time, it would return `None`, but

--- a/examples/gpio_input.rs
+++ b/examples/gpio_input.rs
@@ -1,12 +1,14 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, Peripherals};
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     // Get access to the device's peripherals. Since only one instance of this
     // struct can exist, the call to `take` returns an `Option<Peripherals>`.
     // If we tried to call the method a second time, it would return `None`, but

--- a/examples/gpio_simple.rs
+++ b/examples/gpio_simple.rs
@@ -1,12 +1,14 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, Peripherals};
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     // Get access to the device's peripherals. Since only one instance of this
     // struct can exist, the call to `take` returns an `Option<Peripherals>`.
     // If we tried to call the method a second time, it would return `None`, but

--- a/examples/gpio_sleep.rs
+++ b/examples/gpio_sleep.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{
     clock::Ticks, cortex_m_rt::entry, gpio::Level, prelude::*, sleep,
@@ -10,6 +10,8 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     // Get access to the device's peripherals. Since only one instance of this
     // struct can exist, the call to `take` returns an `Option<Peripherals>`.
     // If we tried to call the method a second time, it would return `None`, but

--- a/examples/gpio_timer.rs
+++ b/examples/gpio_timer.rs
@@ -1,13 +1,15 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{cortex_m_rt::entry, gpio::Level, prelude::*, Peripherals};
 
 use nb::block;
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     // Get access to the device's peripherals. Since only one instance of this
     // struct can exist, the call to `take` returns an `Option<Peripherals>`.
     // If we tried to call the method a second time, it would return `None`, but

--- a/examples/i2c_eeprom.rs
+++ b/examples/i2c_eeprom.rs
@@ -10,7 +10,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use core::fmt::Write;
 
@@ -21,6 +21,8 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 

--- a/examples/i2c_vl53l0x.rs
+++ b/examples/i2c_vl53l0x.rs
@@ -11,7 +11,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use core::fmt::Write;
 
@@ -19,6 +19,8 @@ use lpc8xx_hal::{cortex_m_rt::entry, i2c, prelude::*, usart, Peripherals};
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     let p = Peripherals::take().unwrap();
 
     let i2c = p.I2C0;

--- a/examples/pinint.rs
+++ b/examples/pinint.rs
@@ -1,6 +1,8 @@
 #![no_main]
 #![no_std]
 
+extern crate panic_rtt_target;
+
 use lpc8xx_hal::{
     gpio::{direction::Output, GpioPin, Level},
     init_state::Enabled,
@@ -8,7 +10,6 @@ use lpc8xx_hal::{
     pins::{PIO0_4, PIO1_1},
     Peripherals,
 };
-use panic_halt as _;
 
 #[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {
@@ -19,6 +20,8 @@ const APP: () = {
 
     #[init]
     fn init(_: init::Context) -> init::LateResources {
+        rtt_target::rtt_init_print!();
+
         let p = Peripherals::take().unwrap();
 
         let mut syscon = p.SYSCON.split();

--- a/examples/pmu.rs
+++ b/examples/pmu.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{
     cortex_m::interrupt,
@@ -16,6 +16,8 @@ use lpc8xx_hal::{
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     let cp = CorePeripherals::take().unwrap();
     let p = Peripherals::take().unwrap();
 

--- a/examples/rtfm.rs
+++ b/examples/rtfm.rs
@@ -1,6 +1,8 @@
 #![no_main]
 #![no_std]
 
+extern crate panic_rtt_target;
+
 use lpc8xx_hal::{
     delay::Delay,
     gpio::{direction::Output, GpioPin, Level},
@@ -8,7 +10,6 @@ use lpc8xx_hal::{
     prelude::*,
     Peripherals,
 };
-use panic_halt as _;
 
 #[rtic::app(device = lpc8xx_hal::pac)]
 const APP: () = {
@@ -19,6 +20,8 @@ const APP: () = {
 
     #[init]
     fn init(cx: init::Context) -> init::LateResources {
+        rtt_target::rtt_init_print!();
+
         let p = Peripherals::take().unwrap();
 
         let delay = Delay::new(cx.core.SYST);

--- a/examples/spi_apa102.rs
+++ b/examples/spi_apa102.rs
@@ -1,7 +1,7 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{cortex_m_rt::entry, prelude::*, spi, Peripherals};
 
@@ -9,6 +9,8 @@ use embedded_hal::spi::{Mode, Phase, Polarity};
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     const MODE: Mode = Mode {
         polarity: Polarity::IdleHigh,
         phase: Phase::CaptureOnSecondTransition,

--- a/examples/usart.rs
+++ b/examples/usart.rs
@@ -1,12 +1,14 @@
 #![no_main]
 #![no_std]
 
-extern crate panic_halt;
+extern crate panic_rtt_target;
 
 use lpc8xx_hal::{cortex_m_rt::entry, prelude::*, usart, Peripherals};
 
 #[entry]
 fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
     let p = Peripherals::take().unwrap();
 
     let swm = p.SWM.split();


### PR DESCRIPTION
I've left the OpenOCD configuration in the repository, as cargo-embed isn't a full replacement yet (GDB server doesn't seem to be fully-featured). But I think this configuration is a better default, especially with probe-rs's pace of development.