### PR TITLE
Fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ required-features = ["rt-selected", "845"]
 name              = "spi_apa102"
 required-features = ["rt-selected"]
 
+
 [profile.dev]
 debug = true
 
@@ -165,3 +166,7 @@ debug = true
 debug = true
 lto = true
 opt-level = "s"
+
+
+[package.metadata.docs.rs]
+features = ["845"]


### PR DESCRIPTION
It has been broken for the 0.7.x releases. This should do it.