### PR TITLE
Improve robustness of I2C code

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -59,6 +59,8 @@ mod instances;
 mod interrupts;
 mod peripheral;
 
+pub mod master;
+
 pub use self::{
     clock::{Clock, ClockSource},
     error::Error,

--- a/src/i2c/error.rs
+++ b/src/i2c/error.rs
@@ -1,4 +1,4 @@
-use super::Instance;
+use super::{master, Instance};
 
 /// I2C error
 #[derive(Debug, Eq, PartialEq)]
@@ -27,6 +27,18 @@ pub enum Error {
     ///
     /// Corresponds to the SCLTIMEOUT flag in the STAT register.
     SclTimeout,
+
+    /// The I2C code encountered an unexpected hardware state
+    UnexpectedState {
+        /// The state that was expected
+        expected: master::State,
+
+        /// The state that was actually set
+        ///
+        /// The `Ok` variant represents a valid state. The `Err` variant
+        /// represents an invalid bit pattern in the MSTSTATE field.
+        actual: Result<master::State, u8>,
+    },
 }
 
 impl Error {

--- a/src/i2c/error.rs
+++ b/src/i2c/error.rs
@@ -42,31 +42,31 @@ pub enum Error {
 }
 
 impl Error {
-    pub(super) fn read<I: Instance>(i2c: &I) -> Option<Self> {
+    pub(super) fn read<I: Instance>(i2c: &I) -> Result<(), Self> {
         let stat = i2c.stat.read();
 
         // Check for error flags. If one is set, clear it and return the error.
         if stat.mstarbloss().bit_is_set() {
             i2c.stat.write(|w| w.mstarbloss().set_bit());
-            return Some(Self::MasterArbitrationLoss);
+            return Err(Self::MasterArbitrationLoss);
         }
         if stat.mstststperr().bit_is_set() {
             i2c.stat.write(|w| w.mstststperr().set_bit());
-            return Some(Self::MasterStartStopError);
+            return Err(Self::MasterStartStopError);
         }
         if stat.monov().bit_is_set() {
             i2c.stat.write(|w| w.monov().set_bit());
-            return Some(Self::MonitorOverflow);
+            return Err(Self::MonitorOverflow);
         }
         if stat.eventtimeout().bit_is_set() {
             i2c.stat.write(|w| w.eventtimeout().set_bit());
-            return Some(Self::EventTimeout);
+            return Err(Self::EventTimeout);
         }
         if stat.scltimeout().bit_is_set() {
             i2c.stat.write(|w| w.scltimeout().set_bit());
-            return Some(Self::SclTimeout);
+            return Err(Self::SclTimeout);
         }
 
-        None
+        Ok(())
     }
 }

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -1,0 +1,48 @@
+//! API related to master mode
+
+use core::convert::TryFrom;
+
+use crate::pac::{generic::Variant, i2c0::stat::MSTSTATE_A};
+
+/// The state of an I2C instance set to master mode
+#[derive(Debug, Eq, PartialEq)]
+pub enum State {
+    /// The peripheral is currently idle
+    ///
+    /// A new transaction can be started.
+    Idle,
+
+    /// Data has been received an is available to be read
+    ///
+    /// A read transaction has previously been initiated, and has been
+    /// acknowledged by the slave.
+    RxReady,
+
+    /// Data can be transmitted
+    ///
+    /// A write transaction has previously been initiated, and has been
+    /// acknowledged by the slave.
+    TxReady,
+
+    /// Slave has sent NACK in response to an address
+    NackAddress,
+
+    /// Slave has sent NACK in response to data
+    NackData,
+}
+
+impl TryFrom<Variant<u8, MSTSTATE_A>> for State {
+    /// The value of the MSTSTATE field, if unexpected
+    type Error = u8;
+
+    fn try_from(state: Variant<u8, MSTSTATE_A>) -> Result<Self, Self::Error> {
+        match state {
+            Variant::Val(MSTSTATE_A::IDLE) => Ok(Self::Idle),
+            Variant::Val(MSTSTATE_A::RECEIVE_READY) => Ok(Self::RxReady),
+            Variant::Val(MSTSTATE_A::TRANSMIT_READY) => Ok(Self::TxReady),
+            Variant::Val(MSTSTATE_A::NACK_ADDRESS) => Ok(Self::NackAddress),
+            Variant::Val(MSTSTATE_A::NACK_DATA) => Ok(Self::NackData),
+            Variant::Res(bits) => Err(bits),
+        }
+    }
+}

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -239,13 +239,14 @@ where
             .mstdat
             .write(|w| unsafe { w.data().bits(address | 0x01) });
 
-        // Start transmission
-        self.i2c.mstctl.write(|w| w.mststart().start());
-
-        for b in buffer {
-            // Continue transmission
-            self.i2c.mstctl.write(|w| w.mstcontinue().continue_());
-
+        for (i, b) in buffer.iter_mut().enumerate() {
+            if i == 0 {
+                // Start transmission
+                self.i2c.mstctl.write(|w| w.mststart().start());
+            } else {
+                // Continue transmission
+                self.i2c.mstctl.write(|w| w.mstcontinue().continue_());
+            }
             self.wait_for_state(master::State::RxReady)?;
 
             // Read received byte

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -109,9 +109,7 @@ where
     /// state that requires software interaction.
     fn wait_for_state(&self, expected: master::State) -> Result<(), Error> {
         while self.i2c.stat.read().mstpending().is_in_progress() {
-            if let Some(error) = Error::read(&self.i2c) {
-                return Err(error);
-            }
+            Error::read(&self.i2c)?;
         }
 
         let actual = self.i2c.stat.read().mststate().variant().try_into();
@@ -151,7 +149,7 @@ where
     ///
     /// This method can be used to read and clear all currently detected errors
     /// before resuming normal operation.
-    pub fn read_error(&mut self) -> Option<Error> {
+    pub fn read_error(&mut self) -> Result<(), Error> {
         Error::read(&self.i2c)
     }
 }

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -212,7 +212,7 @@ where
         self.wait_for_state(master::State::TxReady)?;
 
         // Stop transmission
-        self.i2c.mstctl.modify(|_, w| w.mststop().stop());
+        self.i2c.mstctl.write(|w| w.mststop().stop());
 
         Ok(())
     }
@@ -255,7 +255,7 @@ where
         }
 
         // Stop transmission
-        self.i2c.mstctl.modify(|_, w| w.mststop().stop());
+        self.i2c.mstctl.write(|w| w.mststop().stop());
 
         Ok(())
     }


### PR DESCRIPTION
I've been having massive problems getting I2C slave mode to work. In the end it turned out my problems were hardware-related, but these are some software improvements that came out of the whole ordeal.