### PR TITLE
Clean up DMA module

### DIFF
--- a/examples/usart_dma.rs
+++ b/examples/usart_dma.rs
@@ -3,7 +3,7 @@
 
 extern crate panic_rtt_target;
 
-use lpc8xx_hal::{cortex_m_rt::entry, dma, usart, Peripherals};
+use lpc8xx_hal::{cortex_m_rt::entry, usart, Peripherals};
 
 #[entry]
 fn main() -> ! {
@@ -11,13 +11,8 @@ fn main() -> ! {
 
     let p = Peripherals::take().unwrap();
 
-    static mut DMA_DESCRIPTOR: dma::DescriptorTable =
-        dma::DescriptorTable::new();
-    // Sound, as this is the only place where we do this.
-    let dma_descriptors = unsafe { &mut DMA_DESCRIPTOR };
-
     let swm = p.SWM.split();
-    let dma = p.DMA.split(dma_descriptors);
+    let dma = p.DMA.split();
     let mut syscon = p.SYSCON.split();
 
     let dma_handle = dma.handle.enable(&mut syscon.handle);

--- a/examples/usart_dma.rs
+++ b/examples/usart_dma.rs
@@ -12,10 +12,9 @@ fn main() -> ! {
     let p = Peripherals::take().unwrap();
 
     let swm = p.SWM.split();
-    let dma = p.DMA.split();
     let mut syscon = p.SYSCON.split();
 
-    let dma_handle = dma.handle.enable(&mut syscon.handle);
+    let dma_handle = p.DMA.handle.enable(&mut syscon.handle);
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 
     let clock_config = usart::Clock::new_with_baudrate(115200);
@@ -33,8 +32,8 @@ fn main() -> ! {
         p.USART0
             .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
 
-    let mut rx_channel = dma.channels.channel0.enable(&dma_handle);
-    let mut tx_channel = dma.channels.channel1.enable(&dma_handle);
+    let mut rx_channel = p.DMA.channels.channel0.enable(&dma_handle);
+    let mut tx_channel = p.DMA.channels.channel1.enable(&dma_handle);
 
     static mut BUF: [u8; 4] = [0; 4];
 

--- a/examples/usart_dma.rs
+++ b/examples/usart_dma.rs
@@ -14,7 +14,7 @@ fn main() -> ! {
     let swm = p.SWM.split();
     let mut syscon = p.SYSCON.split();
 
-    let dma_handle = p.DMA.handle.enable(&mut syscon.handle);
+    let dma = p.DMA.enable(&mut syscon.handle);
     let mut swm_handle = swm.handle.enable(&mut syscon.handle);
 
     let clock_config = usart::Clock::new_with_baudrate(115200);
@@ -32,8 +32,8 @@ fn main() -> ! {
         p.USART0
             .enable(&clock_config, &mut syscon.handle, u0_rxd, u0_txd);
 
-    let mut rx_channel = p.DMA.channels.channel0.enable(&dma_handle);
-    let mut tx_channel = p.DMA.channels.channel1.enable(&dma_handle);
+    let mut rx_channel = dma.channels.channel0;
+    let mut tx_channel = dma.channels.channel1;
 
     static mut BUF: [u8; 4] = [0; 4];
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -10,7 +10,6 @@ mod transfer;
 
 pub use self::{
     channels::*,
-    descriptors::DescriptorTable,
     peripheral::{Handle, DMA},
     transfer::{Dest, Payload, Source, Transfer},
 };

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -10,6 +10,6 @@ mod transfer;
 
 pub use self::{
     channels::*,
-    peripheral::{Handle, DMA},
+    peripheral::DMA,
     transfer::{Dest, Payload, Source, Transfer},
 };

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -5,11 +5,13 @@
 mod buffer;
 mod channels;
 mod descriptors;
+mod gen;
 mod peripheral;
 mod transfer;
 
 pub use self::{
-    channels::*,
+    channels::{Channel, ChannelTrait},
+    gen::*,
     peripheral::DMA,
     transfer::{Dest, Payload, Source, Transfer},
 };

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -3,14 +3,15 @@
 //! The DMA controller is described in the user manual, chapter 12.
 
 mod buffer;
-mod channels;
 mod descriptors;
 mod gen;
 mod peripheral;
 mod transfer;
 
+pub mod channels;
+
 pub use self::{
-    channels::{Channel, ChannelTrait},
+    channels::Channel,
     gen::*,
     peripheral::DMA,
     transfer::{Dest, Payload, Source, Transfer},

--- a/src/dma/channels.rs
+++ b/src/dma/channels.rs
@@ -12,15 +12,15 @@ use crate::{
     reg_proxy::{Reg, RegProxy},
 };
 
-use super::descriptors::{ChannelDescriptor, DescriptorTable};
+use super::descriptors::ChannelDescriptor;
 
 /// A DMA channel
 pub struct Channel<C, S>
 where
     C: ChannelTrait,
 {
-    ty: C,
-    _state: S,
+    pub(super) ty: C,
+    pub(super) _state: S,
     pub(super) descriptor: &'static mut ChannelDescriptor,
 
     // This channel's dedicated registers.
@@ -33,7 +33,7 @@ where
     C: ChannelTrait,
 {
     /// Enable the channel
-    fn enable(self) -> Channel<C, Enabled> {
+    pub(super) fn enable(self) -> Channel<C, Enabled> {
         Channel {
             ty: self.ty,
             _state: Enabled(()),
@@ -50,7 +50,7 @@ where
     C: ChannelTrait,
 {
     /// Disable the channel
-    fn disable(self) -> Channel<C, Disabled> {
+    pub(super) fn disable(self) -> Channel<C, Disabled> {
         Channel {
             ty: self.ty,
             _state: Disabled,
@@ -81,134 +81,6 @@ pub trait ChannelTrait {
     /// The type that represents this channel's XFERCFG register
     type Xfercfg: Reg<Target = XFERCFG>;
 }
-
-macro_rules! channels {
-    ($($field:ident, $name:ident, $index:expr, $cfg:ident, $xfercfg:ident;)*) => {
-        /// Provides access to all channels
-        #[allow(missing_docs)]
-        pub struct Channels<State> {
-            $(pub $field: Channel<$name, State>,)*
-        }
-
-        impl Channels<Disabled> {
-            pub(super) fn new(descriptors: &'static mut DescriptorTable)
-                -> Self
-            {
-                let mut descriptors = (&mut descriptors.0).into_iter();
-
-                Channels {
-                    $(
-                        $field: Channel {
-                            ty        : $name(()),
-                            _state    : Disabled,
-                            descriptor: descriptors.next().unwrap(),
-
-                            cfg    : RegProxy::new(),
-                            xfercfg: RegProxy::new(),
-                        },
-                    )*
-                }
-            }
-
-            pub(super) fn enable(self) -> Channels<Enabled> {
-                Channels {
-                    $(
-                        $field: self.$field.enable(),
-                    )*
-                }
-            }
-        }
-
-        impl Channels<Enabled> {
-            pub(super) fn disable(self) -> Channels<Disabled> {
-                Channels {
-                    $(
-                        $field: self.$field.disable(),
-                    )*
-                }
-            }
-        }
-
-
-        $(
-            /// This struct is an implementation detail that shouldn't be used by user
-            pub struct $xfercfg;
-
-            reg_cluster!($xfercfg, XFERCFG, pac::DMA0, $field, xfercfg);
-
-            /// This struct is an implementation detail that shouldn't be used by user
-            pub struct $cfg;
-
-            reg_cluster!($cfg, CFG, pac::DMA0, $field, cfg);
-
-            /// Identifies a DMA channel
-            pub struct $name(());
-
-            impl ChannelTrait for $name {
-                const INDEX: usize = $index;
-                const FLAG : u32   = 0x1 << Self::INDEX;
-
-                type Cfg     = $cfg;
-                type Xfercfg = $xfercfg;
-            }
-        )*
-    }
-}
-
-#[cfg(feature = "82x")]
-// The channels must always be specified in order, from lowest to highest, as
-// the channel descriptors are assigned based on that order.
-channels!(
-    channel0 , Channel0 ,  0, CFG0 , XFERCFG0 ;
-    channel1 , Channel1 ,  1, CFG1 , XFERCFG1 ;
-    channel2 , Channel2 ,  2, CFG2 , XFERCFG2 ;
-    channel3 , Channel3 ,  3, CFG3 , XFERCFG3 ;
-    channel4 , Channel4 ,  4, CFG4 , XFERCFG4 ;
-    channel5 , Channel5 ,  5, CFG5 , XFERCFG5 ;
-    channel6 , Channel6 ,  6, CFG6 , XFERCFG6 ;
-    channel7 , Channel7 ,  7, CFG7 , XFERCFG7 ;
-    channel8 , Channel8 ,  8, CFG8 , XFERCFG8 ;
-    channel9 , Channel9 ,  9, CFG9 , XFERCFG9 ;
-    channel10, Channel10, 10, CFG10, XFERCFG10;
-    channel11, Channel11, 11, CFG11, XFERCFG11;
-    channel12, Channel12, 12, CFG12, XFERCFG12;
-    channel13, Channel13, 13, CFG13, XFERCFG13;
-    channel14, Channel14, 14, CFG14, XFERCFG14;
-    channel15, Channel15, 15, CFG15, XFERCFG15;
-    channel16, Channel16, 16, CFG16, XFERCFG16;
-    channel17, Channel17, 17, CFG17, XFERCFG17;
-);
-
-#[cfg(feature = "845")]
-// The channels must always be specified in order, from lowest to highest, as
-// the channel descriptors are assigned based on that order.
-channels!(
-    channel0 , Channel0 ,  0, CFG0 , XFERCFG0 ;
-    channel1 , Channel1 ,  1, CFG1 , XFERCFG1 ;
-    channel2 , Channel2 ,  2, CFG2 , XFERCFG2 ;
-    channel3 , Channel3 ,  3, CFG3 , XFERCFG3 ;
-    channel4 , Channel4 ,  4, CFG4 , XFERCFG4 ;
-    channel5 , Channel5 ,  5, CFG5 , XFERCFG5 ;
-    channel6 , Channel6 ,  6, CFG6 , XFERCFG6 ;
-    channel7 , Channel7 ,  7, CFG7 , XFERCFG7 ;
-    channel8 , Channel8 ,  8, CFG8 , XFERCFG8 ;
-    channel9 , Channel9 ,  9, CFG9 , XFERCFG9 ;
-    channel10, Channel10, 10, CFG10, XFERCFG10;
-    channel11, Channel11, 11, CFG11, XFERCFG11;
-    channel12, Channel12, 12, CFG12, XFERCFG12;
-    channel13, Channel13, 13, CFG13, XFERCFG13;
-    channel14, Channel14, 14, CFG14, XFERCFG14;
-    channel15, Channel15, 15, CFG15, XFERCFG15;
-    channel16, Channel16, 16, CFG16, XFERCFG16;
-    channel17, Channel17, 17, CFG17, XFERCFG17;
-    channel18, Channel18, 18, CFG18, XFERCFG18;
-    channel19, Channel19, 19, CFG19, XFERCFG19;
-    channel20, Channel20, 20, CFG20, XFERCFG20;
-    channel21, Channel21, 21, CFG21, XFERCFG21;
-    channel22, Channel22, 22, CFG22, XFERCFG22;
-    channel23, Channel23, 23, CFG23, XFERCFG23;
-    channel24, Channel24, 24, CFG24, XFERCFG24;
-);
 
 pub(super) struct SharedRegisters<C> {
     active0: &'static ACTIVE0,

--- a/src/dma/channels.rs
+++ b/src/dma/channels.rs
@@ -24,17 +24,17 @@ where
 {
     ty: C,
     _state: S,
-    descriptor: &'static mut ChannelDescriptor,
+    pub(super) descriptor: &'static mut ChannelDescriptor,
 
     // This channel's dedicated registers.
-    cfg: RegProxy<C::Cfg>,
-    xfercfg: RegProxy<C::Xfercfg>,
+    pub(super) cfg: RegProxy<C::Cfg>,
+    pub(super) xfercfg: RegProxy<C::Xfercfg>,
 
     // Shared registers. We restrict our access to the one bit that is dedicated
     // to this channel, so sharing those with other channels should be safe.
     pub(super) active0: RegProxy<ACTIVE0>,
-    enableset0: RegProxy<ENABLESET0>,
-    settrig0: RegProxy<SETTRIG0>,
+    pub(super) enableset0: RegProxy<ENABLESET0>,
+    pub(super) settrig0: RegProxy<SETTRIG0>,
 }
 
 impl<C> Channel<C, init_state::Disabled>

--- a/src/dma/channels.rs
+++ b/src/dma/channels.rs
@@ -1,3 +1,5 @@
+//! APIs related to DMA channels
+
 use core::marker::PhantomData;
 
 use crate::{
@@ -17,7 +19,7 @@ use super::descriptors::ChannelDescriptor;
 /// A DMA channel
 pub struct Channel<C, S>
 where
-    C: ChannelTrait,
+    C: Instance,
 {
     pub(super) ty: C,
     pub(super) _state: S,
@@ -30,7 +32,7 @@ where
 
 impl<C> Channel<C, Disabled>
 where
-    C: ChannelTrait,
+    C: Instance,
 {
     /// Enable the channel
     pub(super) fn enable(self) -> Channel<C, Enabled> {
@@ -47,7 +49,7 @@ where
 
 impl<C> Channel<C, Enabled>
 where
-    C: ChannelTrait,
+    C: Instance,
 {
     /// Disable the channel
     pub(super) fn disable(self) -> Channel<C, Disabled> {
@@ -63,7 +65,7 @@ where
 }
 
 /// Implemented for each DMA channel
-pub trait ChannelTrait {
+pub trait Instance {
     /// The index of the channel
     ///
     /// This is `0` for channel 0, `1` for channel 1, etc.
@@ -92,7 +94,7 @@ pub(super) struct SharedRegisters<C> {
 
 impl<C> SharedRegisters<C>
 where
-    C: ChannelTrait,
+    C: Instance,
 {
     pub(super) fn new() -> Self {
         // This is sound, for the following reasons:

--- a/src/dma/channels.rs
+++ b/src/dma/channels.rs
@@ -12,7 +12,10 @@ use crate::{
     reg_proxy::{Reg, RegProxy},
 };
 
-use super::{descriptors::ChannelDescriptor, DescriptorTable, Handle};
+use super::{
+    descriptors::{ChannelDescriptor, DescriptorTable},
+    Handle,
+};
 
 /// A DMA channel
 pub struct Channel<C, S>

--- a/src/dma/channels.rs
+++ b/src/dma/channels.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use crate::{
-    init_state,
+    init_state::{Disabled, Enabled},
     pac::{
         self,
         dma0::{
@@ -31,7 +31,7 @@ where
     pub(super) xfercfg: RegProxy<C::Xfercfg>,
 }
 
-impl<C> Channel<C, init_state::Disabled>
+impl<C> Channel<C, Disabled>
 where
     C: ChannelTrait,
 {
@@ -39,10 +39,10 @@ where
     pub fn enable<'dma>(
         self,
         dma: &'dma Handle,
-    ) -> Channel<C, init_state::Enabled<&'dma Handle>> {
+    ) -> Channel<C, Enabled<&'dma Handle>> {
         Channel {
             ty: self.ty,
-            _state: init_state::Enabled(dma),
+            _state: Enabled(dma),
             descriptor: self.descriptor,
 
             cfg: self.cfg,
@@ -76,7 +76,7 @@ macro_rules! channels {
         /// Provides access to all channels
         #[allow(missing_docs)]
         pub struct Channels {
-            $(pub $field: Channel<$name, init_state::Disabled>,)*
+            $(pub $field: Channel<$name, Disabled>,)*
         }
 
         impl Channels {
@@ -89,7 +89,7 @@ macro_rules! channels {
                     $(
                         $field: Channel {
                             ty        : $name(()),
-                            _state    : init_state::Disabled,
+                            _state    : Disabled,
                             descriptor: descriptors.next().unwrap(),
 
                             cfg    : RegProxy::new(),

--- a/src/dma/descriptors.rs
+++ b/src/dma/descriptors.rs
@@ -1,5 +1,7 @@
 use core::ptr;
 
+pub(super) static mut DESCRIPTORS: DescriptorTable = DescriptorTable::new();
+
 /// The channel descriptor table
 ///
 /// Contains a descriptor for each DMA channel.

--- a/src/dma/descriptors.rs
+++ b/src/dma/descriptors.rs
@@ -6,7 +6,7 @@ pub(super) static mut DESCRIPTORS: DescriptorTable = DescriptorTable::new();
 ///
 /// Contains a descriptor for each DMA channel.
 #[repr(C, align(512))]
-pub struct DescriptorTable(
+pub(super) struct DescriptorTable(
     pub(super) [ChannelDescriptor; target::NUM_CHANNELS],
 );
 

--- a/src/dma/gen.rs
+++ b/src/dma/gen.rs
@@ -1,0 +1,141 @@
+use crate::{
+    init_state::{Disabled, Enabled},
+    pac::{
+        self,
+        dma0::channel::{CFG, XFERCFG},
+    },
+    reg_proxy::RegProxy,
+};
+
+use super::{
+    channels::{Channel, ChannelTrait},
+    descriptors::DescriptorTable,
+};
+
+macro_rules! channels {
+    ($($field:ident, $name:ident, $index:expr, $cfg:ident, $xfercfg:ident;)*) => {
+        /// Provides access to all channels
+        #[allow(missing_docs)]
+        pub struct Channels<State> {
+            $(pub $field: Channel<$name, State>,)*
+        }
+
+        impl Channels<Disabled> {
+            pub(super) fn new(descriptors: &'static mut DescriptorTable)
+                -> Self
+            {
+                let mut descriptors = (&mut descriptors.0).into_iter();
+
+                Channels {
+                    $(
+                        $field: Channel {
+                            ty        : $name(()),
+                            _state    : Disabled,
+                            descriptor: descriptors.next().unwrap(),
+
+                            cfg    : RegProxy::new(),
+                            xfercfg: RegProxy::new(),
+                        },
+                    )*
+                }
+            }
+
+            pub(super) fn enable(self) -> Channels<Enabled> {
+                Channels {
+                    $(
+                        $field: self.$field.enable(),
+                    )*
+                }
+            }
+        }
+
+        impl Channels<Enabled> {
+            pub(super) fn disable(self) -> Channels<Disabled> {
+                Channels {
+                    $(
+                        $field: self.$field.disable(),
+                    )*
+                }
+            }
+        }
+
+
+        $(
+            /// This struct is an implementation detail that shouldn't be used by user
+            pub struct $xfercfg;
+
+            reg_cluster!($xfercfg, XFERCFG, pac::DMA0, $field, xfercfg);
+
+            /// This struct is an implementation detail that shouldn't be used by user
+            pub struct $cfg;
+
+            reg_cluster!($cfg, CFG, pac::DMA0, $field, cfg);
+
+            /// Identifies a DMA channel
+            pub struct $name(());
+
+            impl ChannelTrait for $name {
+                const INDEX: usize = $index;
+                const FLAG : u32   = 0x1 << Self::INDEX;
+
+                type Cfg     = $cfg;
+                type Xfercfg = $xfercfg;
+            }
+        )*
+    }
+}
+
+#[cfg(feature = "82x")]
+// The channels must always be specified in order, from lowest to highest, as
+// the channel descriptors are assigned based on that order.
+channels!(
+    channel0 , Channel0 ,  0, CFG0 , XFERCFG0 ;
+    channel1 , Channel1 ,  1, CFG1 , XFERCFG1 ;
+    channel2 , Channel2 ,  2, CFG2 , XFERCFG2 ;
+    channel3 , Channel3 ,  3, CFG3 , XFERCFG3 ;
+    channel4 , Channel4 ,  4, CFG4 , XFERCFG4 ;
+    channel5 , Channel5 ,  5, CFG5 , XFERCFG5 ;
+    channel6 , Channel6 ,  6, CFG6 , XFERCFG6 ;
+    channel7 , Channel7 ,  7, CFG7 , XFERCFG7 ;
+    channel8 , Channel8 ,  8, CFG8 , XFERCFG8 ;
+    channel9 , Channel9 ,  9, CFG9 , XFERCFG9 ;
+    channel10, Channel10, 10, CFG10, XFERCFG10;
+    channel11, Channel11, 11, CFG11, XFERCFG11;
+    channel12, Channel12, 12, CFG12, XFERCFG12;
+    channel13, Channel13, 13, CFG13, XFERCFG13;
+    channel14, Channel14, 14, CFG14, XFERCFG14;
+    channel15, Channel15, 15, CFG15, XFERCFG15;
+    channel16, Channel16, 16, CFG16, XFERCFG16;
+    channel17, Channel17, 17, CFG17, XFERCFG17;
+);
+
+#[cfg(feature = "845")]
+// The channels must always be specified in order, from lowest to highest, as
+// the channel descriptors are assigned based on that order.
+channels!(
+    channel0 , Channel0 ,  0, CFG0 , XFERCFG0 ;
+    channel1 , Channel1 ,  1, CFG1 , XFERCFG1 ;
+    channel2 , Channel2 ,  2, CFG2 , XFERCFG2 ;
+    channel3 , Channel3 ,  3, CFG3 , XFERCFG3 ;
+    channel4 , Channel4 ,  4, CFG4 , XFERCFG4 ;
+    channel5 , Channel5 ,  5, CFG5 , XFERCFG5 ;
+    channel6 , Channel6 ,  6, CFG6 , XFERCFG6 ;
+    channel7 , Channel7 ,  7, CFG7 , XFERCFG7 ;
+    channel8 , Channel8 ,  8, CFG8 , XFERCFG8 ;
+    channel9 , Channel9 ,  9, CFG9 , XFERCFG9 ;
+    channel10, Channel10, 10, CFG10, XFERCFG10;
+    channel11, Channel11, 11, CFG11, XFERCFG11;
+    channel12, Channel12, 12, CFG12, XFERCFG12;
+    channel13, Channel13, 13, CFG13, XFERCFG13;
+    channel14, Channel14, 14, CFG14, XFERCFG14;
+    channel15, Channel15, 15, CFG15, XFERCFG15;
+    channel16, Channel16, 16, CFG16, XFERCFG16;
+    channel17, Channel17, 17, CFG17, XFERCFG17;
+    channel18, Channel18, 18, CFG18, XFERCFG18;
+    channel19, Channel19, 19, CFG19, XFERCFG19;
+    channel20, Channel20, 20, CFG20, XFERCFG20;
+    channel21, Channel21, 21, CFG21, XFERCFG21;
+    channel22, Channel22, 22, CFG22, XFERCFG22;
+    channel23, Channel23, 23, CFG23, XFERCFG23;
+    channel24, Channel24, 24, CFG24, XFERCFG24;
+);

--- a/src/dma/gen.rs
+++ b/src/dma/gen.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 use super::{
-    channels::{Channel, ChannelTrait},
+    channels::{self, Channel},
     descriptors::DescriptorTable,
 };
 
@@ -74,7 +74,7 @@ macro_rules! channels {
             /// Identifies a DMA channel
             pub struct $name(());
 
-            impl ChannelTrait for $name {
+            impl channels::Instance for $name {
                 const INDEX: usize = $index;
                 const FLAG : u32   = 0x1 << Self::INDEX;
 

--- a/src/dma/peripheral.rs
+++ b/src/dma/peripheral.rs
@@ -4,25 +4,20 @@ use super::Channels;
 
 /// Entry point to the DMA API
 pub struct DMA {
-    dma: pac::DMA0,
+    /// Handle to the DMA controller
+    pub handle: Handle<init_state::Disabled>,
+
+    /// The DMA channels
+    pub channels: Channels,
 }
 
 impl DMA {
     pub(crate) fn new(dma: pac::DMA0) -> Self {
-        DMA { dma }
-    }
-
-    /// Splits the DMA API into its component parts
-    ///
-    /// This is the regular way to access the DMA API. It exists as an explicit
-    /// step, as it's no longer possible to gain access to the raw peripheral
-    /// using [`DMA::free`] after you've called this method.
-    pub fn split(self) -> Parts {
         let descriptors = unsafe { &mut super::descriptors::DESCRIPTORS };
         let srambase = descriptors as *mut _ as u32;
 
-        Parts {
-            handle: Handle::new(self.dma, srambase),
+        Self {
+            handle: Handle::new(dma, srambase),
             channels: Channels::new(descriptors),
         }
     }
@@ -40,22 +35,8 @@ impl DMA {
     ///
     /// [open an issue]: https://github.com/lpc-rs/lpc8xx-hal/issues
     pub fn free(self) -> pac::DMA0 {
-        self.dma
+        self.handle.dma
     }
-}
-
-/// The main API for the DMA controller
-///
-/// Provides access to all types that make up the DMA API. Please refer to the
-/// [module documentation] for more information.
-///
-/// [module documentation]: index.html
-pub struct Parts {
-    /// Handle to the DMA controller
-    pub handle: Handle<init_state::Disabled>,
-
-    /// The DMA channels
-    pub channels: Channels,
 }
 
 /// Handle to the DMA controller

--- a/src/dma/peripheral.rs
+++ b/src/dma/peripheral.rs
@@ -1,6 +1,6 @@
 use crate::{init_state, pac, syscon};
 
-use super::{Channels, DescriptorTable};
+use super::Channels;
 
 /// Entry point to the DMA API
 pub struct DMA {
@@ -17,7 +17,8 @@ impl DMA {
     /// This is the regular way to access the DMA API. It exists as an explicit
     /// step, as it's no longer possible to gain access to the raw peripheral
     /// using [`DMA::free`] after you've called this method.
-    pub fn split(self, descriptors: &'static mut DescriptorTable) -> Parts {
+    pub fn split(self) -> Parts {
+        let descriptors = unsafe { &mut super::descriptors::DESCRIPTORS };
         let srambase = descriptors as *mut _ as u32;
 
         Parts {

--- a/src/dma/peripheral.rs
+++ b/src/dma/peripheral.rs
@@ -3,65 +3,31 @@ use crate::{init_state, pac, syscon};
 use super::Channels;
 
 /// Entry point to the DMA API
-pub struct DMA {
-    /// Handle to the DMA controller
-    pub handle: Handle<init_state::Disabled>,
+pub struct DMA<State> {
+    dma: pac::DMA0,
+    srambase: u32,
 
     /// The DMA channels
-    pub channels: Channels,
+    pub channels: Channels<State>,
 }
 
-impl DMA {
+impl DMA<init_state::Disabled> {
     pub(crate) fn new(dma: pac::DMA0) -> Self {
         let descriptors = unsafe { &mut super::descriptors::DESCRIPTORS };
         let srambase = descriptors as *mut _ as u32;
 
         Self {
-            handle: Handle::new(dma, srambase),
+            dma,
+            srambase,
             channels: Channels::new(descriptors),
         }
     }
 
-    /// Return the raw peripheral
-    ///
-    /// This method serves as an escape hatch from the HAL API. It returns the
-    /// raw peripheral, allowing you to do whatever you want with it, without
-    /// limitations imposed by the API.
-    ///
-    /// If you are using this method because a feature you need is missing from
-    /// the HAL API, please [open an issue] or, if an issue for your feature
-    /// request already exists, comment on the existing issue, so we can
-    /// prioritize it accordingly.
-    ///
-    /// [open an issue]: https://github.com/lpc-rs/lpc8xx-hal/issues
-    pub fn free(self) -> pac::DMA0 {
-        self.handle.dma
-    }
-}
-
-/// Handle to the DMA controller
-pub struct Handle<State = init_state::Enabled> {
-    _state: State,
-    dma: pac::DMA0,
-    srambase: u32,
-}
-
-impl Handle<init_state::Disabled> {
-    pub(crate) fn new(dma: pac::DMA0, srambase: u32) -> Self {
-        Handle {
-            _state: init_state::Disabled,
-            dma,
-            srambase,
-        }
-    }
-}
-
-impl<'dma> Handle<init_state::Disabled> {
     /// Enable the DMA controller
     pub fn enable(
         self,
         syscon: &mut syscon::Handle,
-    ) -> Handle<init_state::Enabled> {
+    ) -> DMA<init_state::Enabled> {
         syscon.enable_clock(&self.dma);
 
         // Set descriptor table address
@@ -76,26 +42,44 @@ impl<'dma> Handle<init_state::Disabled> {
         // See user manual, section 12.6.1.
         self.dma.ctrl.write(|w| w.enable().enabled());
 
-        Handle {
-            _state: init_state::Enabled(()),
+        DMA {
             dma: self.dma,
             srambase: self.srambase,
+            channels: self.channels.enable(),
         }
     }
 }
 
-impl Handle<init_state::Enabled> {
+impl DMA<init_state::Enabled> {
     /// Disable the DMA controller
     pub fn disable(
         self,
         syscon: &mut syscon::Handle,
-    ) -> Handle<init_state::Disabled> {
+    ) -> DMA<init_state::Disabled> {
         syscon.disable_clock(&self.dma);
 
-        Handle {
-            _state: init_state::Disabled,
+        DMA {
             dma: self.dma,
             srambase: self.srambase,
+            channels: self.channels.disable(),
         }
+    }
+}
+
+impl<State> DMA<State> {
+    /// Return the raw peripheral
+    ///
+    /// This method serves as an escape hatch from the HAL API. It returns the
+    /// raw peripheral, allowing you to do whatever you want with it, without
+    /// limitations imposed by the API.
+    ///
+    /// If you are using this method because a feature you need is missing from
+    /// the HAL API, please [open an issue] or, if an issue for your feature
+    /// request already exists, comment on the existing issue, so we can
+    /// prioritize it accordingly.
+    ///
+    /// [open an issue]: https://github.com/lpc-rs/lpc8xx-hal/issues
+    pub fn free(self) -> pac::DMA0 {
+        self.dma
     }
 }

--- a/src/dma/transfer.rs
+++ b/src/dma/transfer.rs
@@ -10,25 +10,25 @@ use crate::{
 
 use super::{
     channels::{ChannelTrait, SharedRegisters},
-    Channel, Handle,
+    Channel,
 };
 
 /// A DMA transfer
-pub struct Transfer<'dma, C, S, D>
+pub struct Transfer<C, S, D>
 where
     C: ChannelTrait,
 {
-    payload: Payload<'dma, C, S, D>,
+    payload: Payload<C, S, D>,
 }
 
-impl<'dma, C, S, D> Transfer<'dma, C, S, D>
+impl<C, S, D> Transfer<C, S, D>
 where
     C: ChannelTrait,
     S: Source,
     D: Dest,
 {
     pub(super) fn new(
-        channel: Channel<C, Enabled<&'dma Handle>>,
+        channel: Channel<C, Enabled>,
         source: S,
         dest: D,
     ) -> Self {
@@ -53,7 +53,7 @@ where
     /// The caller must make sure to call this method only for the correct
     /// combination of channel and target.
     pub(crate) fn start(
-        channel: Channel<C, Enabled<&'dma Handle>>,
+        channel: Channel<C, Enabled>,
         source: S,
         mut dest: D,
     ) -> Self {
@@ -124,8 +124,7 @@ where
     /// Waits for the transfer to finish
     pub fn wait(
         mut self,
-    ) -> Result<Payload<'dma, C, S, D>, (D::Error, Payload<'dma, C, S, D>)>
-    {
+    ) -> Result<Payload<C, S, D>, (D::Error, Payload<C, S, D>)> {
         // There's an error interrupt status register. Maybe we should check
         // this here, but I have no idea whether that actually makes sense:
         // 1. As of this writing, we're not enabling any interrupts. I don't
@@ -158,12 +157,12 @@ where
 }
 
 /// The payload of a `Transfer`
-pub struct Payload<'dma, C, S, D>
+pub struct Payload<C, S, D>
 where
     C: ChannelTrait,
 {
     /// The channel used for this transfer
-    pub channel: Channel<C, Enabled<&'dma Handle>>,
+    pub channel: Channel<C, Enabled>,
 
     /// The source of the transfer
     pub source: S,
@@ -172,7 +171,7 @@ where
     pub dest: D,
 }
 
-impl<'dma, C, S, D> fmt::Debug for Payload<'dma, C, S, D>
+impl<C, S, D> fmt::Debug for Payload<C, S, D>
 where
     C: ChannelTrait,
 {

--- a/src/dma/transfer.rs
+++ b/src/dma/transfer.rs
@@ -9,21 +9,21 @@ use crate::{
 };
 
 use super::{
-    channels::{ChannelTrait, SharedRegisters},
+    channels::{Instance, SharedRegisters},
     Channel,
 };
 
 /// A DMA transfer
 pub struct Transfer<C, S, D>
 where
-    C: ChannelTrait,
+    C: Instance,
 {
     payload: Payload<C, S, D>,
 }
 
 impl<C, S, D> Transfer<C, S, D>
 where
-    C: ChannelTrait,
+    C: Instance,
     S: Source,
     D: Dest,
 {
@@ -159,7 +159,7 @@ where
 /// The payload of a `Transfer`
 pub struct Payload<C, S, D>
 where
-    C: ChannelTrait,
+    C: Instance,
 {
     /// The channel used for this transfer
     pub channel: Channel<C, Enabled>,
@@ -173,7 +173,7 @@ where
 
 impl<C, S, D> fmt::Debug for Payload<C, S, D>
 where
-    C: ChannelTrait,
+    C: Instance,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Placeholder implementation. Trying to do this properly runs into many

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ pub struct Peripherals {
     pub CTIMER0: CTimer,
 
     /// DMA controller
-    pub DMA: DMA,
+    pub DMA: DMA<init_state::Disabled>,
 
     /// General-purpose I/O (GPIO)
     ///

--- a/src/usart/instances.rs
+++ b/src/usart/instances.rs
@@ -28,10 +28,10 @@ pub trait Instance:
     type Tx;
 
     /// The DMA channel used with this instance for receiving
-    type RxChannel: dma::ChannelTrait;
+    type RxChannel: dma::channels::Instance;
 
     /// The DMA channel used with this instance for transmissions
-    type TxChannel: dma::ChannelTrait;
+    type TxChannel: dma::channels::Instance;
 }
 
 macro_rules! instances {

--- a/src/usart/rx.rs
+++ b/src/usart/rx.rs
@@ -67,7 +67,7 @@ where
         buffer: &'static mut [u8],
         channel: dma::Channel<I::RxChannel, Enabled<&'dma dma::Handle>>,
     ) -> dma::Transfer<'dma, I::RxChannel, Self, &'static mut [u8]> {
-        channel.start_transfer(self, buffer)
+        dma::Transfer::start(channel, self, buffer)
     }
 }
 

--- a/src/usart/rx.rs
+++ b/src/usart/rx.rs
@@ -62,11 +62,11 @@ where
     /// # Panics
     ///
     /// Panics, if `buffer` has a length larger than 1024.
-    pub fn read_all<'dma>(
+    pub fn read_all(
         self,
         buffer: &'static mut [u8],
-        channel: dma::Channel<I::RxChannel, Enabled<&'dma dma::Handle>>,
-    ) -> dma::Transfer<'dma, I::RxChannel, Self, &'static mut [u8]> {
+        channel: dma::Channel<I::RxChannel, Enabled>,
+    ) -> dma::Transfer<I::RxChannel, Self, &'static mut [u8]> {
         dma::Transfer::start(channel, self, buffer)
     }
 }

--- a/src/usart/tx.rs
+++ b/src/usart/tx.rs
@@ -71,7 +71,7 @@ where
         buffer: &'static [u8],
         channel: dma::Channel<I::TxChannel, Enabled<&'dma dma::Handle>>,
     ) -> dma::Transfer<'dma, I::TxChannel, &'static [u8], Self> {
-        channel.start_transfer(buffer, self)
+        dma::Transfer::start(channel, buffer, self)
     }
 }
 

--- a/src/usart/tx.rs
+++ b/src/usart/tx.rs
@@ -66,11 +66,11 @@ where
     /// # Panics
     ///
     /// Panics, if `buffer` has a length larger than 1024.
-    pub fn write_all<'dma>(
+    pub fn write_all(
         self,
         buffer: &'static [u8],
-        channel: dma::Channel<I::TxChannel, Enabled<&'dma dma::Handle>>,
-    ) -> dma::Transfer<'dma, I::TxChannel, &'static [u8], Self> {
+        channel: dma::Channel<I::TxChannel, Enabled>,
+    ) -> dma::Transfer<I::TxChannel, &'static [u8], Self> {
         dma::Transfer::start(channel, buffer, self)
     }
 }


### PR DESCRIPTION
This PR contains multiple orthogonal clean-ups, the most significant of which removes the lifetime from `Channel` and `Transfer`, making the API much more convenient to use in non-trivial use cases.