### PR TITLE
Fix bitwise operator when checking flag

### DIFF
--- a/src/usart/flags.rs
+++ b/src/usart/flags.rs
@@ -35,7 +35,7 @@ macro_rules! flags {
                     $(
                         Self::$name => {
                             let flag = usart.stat.read()
-                                .bits() | (0x1 << $bit_pos);
+                                .bits() & (0x1 << $bit_pos);
                             flags!(@reset, $access, usart, $bit_pos);
                             flag != 0
                         }


### PR DESCRIPTION
I'm not sure how this slipped through my test suite[1], bit it did. I
think ideally (and I've mentioned this before), the flags infrastructure
would be independent of a specific peripheral, and would be used by all
peripherals to manage their flags. Once that is the case, we should find
a way to write some unit tests, but at this moment, I'm not sure exactly
how to do that.

[1] https://github.com/braun-embedded/lpc845-test-stand