### PR TITLE
Fix handling of I2C slave address

### DIFF
--- a/examples/i2c_master_slave.rs
+++ b/examples/i2c_master_slave.rs
@@ -43,7 +43,8 @@ const APP: () = {
             .I2C0
             .enable(&syscon.iosc, i2c0_scl, i2c0_sda, &mut syscon.handle)
             .enable_master_mode(&i2c::Clock::new_400khz())
-            .enable_slave_mode(ADDRESS);
+            .enable_slave_mode(ADDRESS)
+            .expect("`ADDRESS` not a valid 7-bit address");
 
         i2c.enable_interrupts(i2c::Interrupts {
             slave_pending: true,

--- a/examples/i2c_master_slave_dma.rs
+++ b/examples/i2c_master_slave_dma.rs
@@ -47,7 +47,8 @@ const APP: () = {
             .I2C0
             .enable(&syscon.iosc, i2c0_scl, i2c0_sda, &mut syscon.handle)
             .enable_master_mode(&i2c::Clock::new_400khz())
-            .enable_slave_mode(ADDRESS);
+            .enable_slave_mode(ADDRESS)
+            .expect("`ADDRESS` not a valid 7-bit address");
 
         i2c.enable_interrupts(i2c::Interrupts {
             slave_pending: true,

--- a/src/i2c/error.rs
+++ b/src/i2c/error.rs
@@ -51,6 +51,14 @@ pub enum Error {
 }
 
 impl Error {
+    pub(super) fn check_address(address: u8) -> Result<(), Self> {
+        if address > 0b111_1111 {
+            return Err(Self::AddressOutOfRange);
+        }
+
+        Ok(())
+    }
+
     pub(super) fn read<I: Instance>() -> Result<(), Self> {
         // Sound, as we're only reading from the STAT register.
         let i2c = unsafe { &*I::REGISTERS };

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -120,10 +120,7 @@ where
     }
 
     fn start_operation(&mut self, address: u8, rw: Rw) -> Result<(), Error> {
-        if address > 0b111_1111 {
-            return Err(Error::AddressOutOfRange);
-        }
-
+        Error::check_address(address)?;
         self.wait_for_state(State::Idle)?;
 
         // Write address

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -2,6 +2,7 @@
 
 use core::{
     convert::{TryFrom, TryInto as _},
+    fmt,
     marker::PhantomData,
 };
 
@@ -296,6 +297,22 @@ where
     }
 }
 
+// Can't derive, because peripheral structs from the PAC don't implement
+// `Debug`. See https://github.com/rust-embedded/svd2rust/issues/48.
+impl<I, State, ModeState> fmt::Debug for Master<I, State, ModeState>
+where
+    I: Instance,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Master")
+            .field("_state", &self._state)
+            .field("_mode_state", &self._mode_state)
+            .field("mstctl", &self.mstctl)
+            .field("mstdat", &self.mstdat)
+            .finish()
+    }
+}
+
 /// Private helper struct to model the R/W bit
 #[repr(u8)]
 enum Rw {
@@ -362,6 +379,14 @@ where
     }
 }
 
+// Can't derive, because peripheral structs from the PAC don't implement
+// `Debug`. See https://github.com/rust-embedded/svd2rust/issues/48.
+impl<I> fmt::Debug for MstCtl<I> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MstCtl(...)")
+    }
+}
+
 struct MstDat<I>(PhantomData<I>);
 
 // Sound, as the pointer returned is valid for the duration of the program.
@@ -375,5 +400,13 @@ where
         // Sound, as MSTDAT is exclusively used by `Master`, and only one
         // `RegProxy` instance for it exists.
         unsafe { &(*I::REGISTERS).mstdat as *const _ }
+    }
+}
+
+// Can't derive, because peripheral structs from the PAC don't implement
+// `Debug`. See https://github.com/rust-embedded/svd2rust/issues/48.
+impl<I> fmt::Debug for MstDat<I> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MstDat(...)")
     }
 }

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -151,6 +151,9 @@ where
         MasterMode,
         init_state::Enabled,
     > {
+        // This is a placeholder until proper error handling is added.
+        Error::check_address(address).unwrap();
+
         // Enable slave mode
         // Set all other configuration values to default.
         self.i2c.cfg.modify(|_, w| w.slven().enabled());
@@ -160,7 +163,7 @@ where
             w.sadisable().enabled();
 
             // Sound, as all possible 7-bit values are acceptable here.
-            unsafe { w.slvadr().bits(address >> 1) }
+            unsafe { w.slvadr().bits(address) }
         });
 
         I2C {

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -145,14 +145,18 @@ where
     pub fn enable_slave_mode(
         self,
         address: u8,
-    ) -> I2C<
-        I,
-        init_state::Enabled<PhantomData<C>>,
-        MasterMode,
-        init_state::Enabled,
+    ) -> Result<
+        I2C<
+            I,
+            init_state::Enabled<PhantomData<C>>,
+            MasterMode,
+            init_state::Enabled,
+        >,
+        (Error, Self),
     > {
-        // This is a placeholder until proper error handling is added.
-        Error::check_address(address).unwrap();
+        if let Err(err) = Error::check_address(address) {
+            return Err((err, self));
+        }
 
         // Enable slave mode
         // Set all other configuration values to default.
@@ -166,12 +170,12 @@ where
             unsafe { w.slvadr().bits(address) }
         });
 
-        I2C {
+        Ok(I2C {
             master: Master::new(),
             slave: Slave::new(),
 
             i2c: self.i2c,
-        }
+        })
     }
 }
 

--- a/src/i2c/peripheral.rs
+++ b/src/i2c/peripheral.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 use crate::{init_state, swm, syscon};
 
@@ -227,5 +227,21 @@ where
     /// [open an issue]: https://github.com/lpc-rs/lpc8xx-hal/issues
     pub fn free(self) -> I {
         self.i2c
+    }
+}
+
+// Can't derive, because peripheral structs from the PAC don't implement
+// `Debug`. See https://github.com/rust-embedded/svd2rust/issues/48.
+impl<I, State, MasterMode, SlaveMode> fmt::Debug
+    for I2C<I, State, MasterMode, SlaveMode>
+where
+    I: Instance,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("I2C")
+            .field("master", &self.master)
+            .field("slave", &self.slave)
+            .field("i2c", &"i2c")
+            .finish()
     }
 }

--- a/src/i2c/slave.rs
+++ b/src/i2c/slave.rs
@@ -1,6 +1,6 @@
 //! API for the I2C slave mode
 
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 use crate::{
     init_state,
@@ -84,6 +84,22 @@ where
         Err(nb::Error::Other(Error::UnknownSlaveState(
             slave_state.bits(),
         )))
+    }
+}
+
+// Can't derive, because peripheral structs from the PAC don't implement
+// `Debug`. See https://github.com/rust-embedded/svd2rust/issues/48.
+impl<I, State, ModeState> fmt::Debug for Slave<I, State, ModeState>
+where
+    I: Instance,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Slave")
+            .field("_state", &self._state)
+            .field("_mode_state", &self._mode_state)
+            .field("slvctl", &self.slvctl)
+            .field("slvdat", &self.slvdat)
+            .finish()
     }
 }
 
@@ -238,6 +254,14 @@ where
     }
 }
 
+// Can't derive, because peripheral structs from the PAC don't implement
+// `Debug`. See https://github.com/rust-embedded/svd2rust/issues/48.
+impl<I> fmt::Debug for SlvCtl<I> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SlvCtl(...)")
+    }
+}
+
 struct SlvDat<I>(PhantomData<I>);
 
 // Sound, as the pointer returned is valid for the duration of the program.
@@ -251,5 +275,13 @@ where
         // Sound, as SLVDAT is exclusively used by `Slave`, and only one
         // `RegProxy` instance for it exists.
         unsafe { &(*I::REGISTERS).slvdat as *const _ }
+    }
+}
+
+// Can't derive, because peripheral structs from the PAC don't implement
+// `Debug`. See https://github.com/rust-embedded/svd2rust/issues/48.
+impl<I> fmt::Debug for SlvDat<I> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SlvDat(...)")
     }
 }

--- a/src/reg_proxy.rs
+++ b/src/reg_proxy.rs
@@ -16,6 +16,7 @@ use core::ops::Deref;
 /// This proxy can be moved and owned, then provide access to the register it
 /// proxies from wherever it is. Access to the register is provided by
 /// implementing `Deref`.
+#[derive(Debug)]
 pub struct RegProxy<T>
 where
     T: Reg,


### PR DESCRIPTION
Follow-up to #282 by @jacobbramley. Turns out we missed one place that had to be modified.