### PR TITLE
Update and pin embedded-hal alpha version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ version  = "0.2.4"
 features = ["unproven"]
 
 [dependencies.embedded-hal-alpha]
-version = "1.0.0-alpha.1"
+version = "=1.0.0-alpha.2"
 package = "embedded-hal"
 
 [dependencies.lpc82x-pac]


### PR DESCRIPTION
It has recently come to my attention that Cargo treats different alpha
versions as semver-compatible. This is bad, as those could contain
breaking changes, and a simple `cargo update` by a user of LPC8xx HAL
could break their build.

Pinning to one specific alpha version should fix that particular
problem.