### PR TITLE
Add DynamicPin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,10 @@ name              = "gpio_delay"
 required-features = ["rt-selected"]
 
 [[example]]
+name              = "gpio_dynamic"
+required-features = ["rt-selected"]
+
+[[example]]
 name              = "gpio_input"
 required-features = ["rt-selected", "845"]
 

--- a/examples/gpio_dynamic.rs
+++ b/examples/gpio_dynamic.rs
@@ -1,0 +1,51 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_rtt_target;
+
+use lpc8xx_hal::{
+    cortex_m_rt::entry, gpio::Level, pins::DynamicPinDirection, Peripherals,
+};
+
+#[entry]
+fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
+    // Get access to the device's peripherals. Since only one instance of this
+    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // If we tried to call the method a second time, it would return `None`, but
+    // we're only calling it the one time here, so we can safely `unwrap` the
+    // `Option` without causing a panic.
+    let p = Peripherals::take().unwrap();
+
+    // Initialize the APIs of the peripherals we need.
+    #[cfg(feature = "82x")]
+    let gpio = p.GPIO; // GPIO is initialized by default on LPC82x.
+    #[cfg(feature = "845")]
+    let gpio = {
+        let mut syscon = p.SYSCON.split();
+        p.GPIO.enable(&mut syscon.handle)
+    };
+
+    // Select pin for LED
+    #[cfg(feature = "82x")]
+    let (led, token) = (p.pins.pio0_12, gpio.tokens.pio0_12);
+    #[cfg(feature = "845")]
+    let (led, token) = (p.pins.pio1_1, gpio.tokens.pio1_1);
+
+    // Configure the LED pin as dynamic, with its initial direction being Input.
+    // A dynamic pin can change ist direction at runtime, but will not give you the same
+    // compile-time guarantees a unidirectinal pin gives you.
+    let mut led =
+        led.into_dynamic_pin(token, Level::Low, DynamicPinDirection::Input);
+
+    // Blink the LED by toggling the pin direction
+    loop {
+        for _ in 0..10_000 {
+            led.switch_to_output(Level::Low);
+        }
+        for _ in 0..10_000 {
+            led.switch_to_input();
+        }
+    }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -261,7 +261,7 @@ where
 
     /// Set pin direction to dynamic (i.e. changeable at runtime)
     ///
-    /// This method is only available while the pin is in input mode.
+    /// This method is only available when the pin is not already in dynamic mode.
     ///
     /// Consumes the pin instance and returns a new instance that is in dynamic
     /// mode, making the methods to change direction as well as read/set levels
@@ -348,7 +348,7 @@ where
 
     /// Set pin direction to dynamic (i.e. changeable at runtime)
     ///
-    /// This method is only available while the pin is in output mode.
+    /// This method is only available when the pin is not already in dynamic mode.
     ///
     /// Consumes the pin instance and returns a new instance that is in dynamic
     /// mode, making the methods to change direction as well as read/set levels

--- a/src/mrt.rs
+++ b/src/mrt.rs
@@ -1,4 +1,4 @@
-//! API for the MRT peripheral
+//! API for the MRT (Multi-Rate Timer) peripheral
 //!
 //! Please be aware that this doesn't try to abstract everything, it only
 //! implements the embedded-hal `Timer` functionality.

--- a/src/pins/mod.rs
+++ b/src/pins/mod.rs
@@ -11,4 +11,6 @@ mod traits;
 
 pub mod state;
 
-pub use self::{gen::*, pin::Pin, state::State, traits::Trait};
+pub use self::{
+    gen::*, pin::DynamicPinDirection, pin::Pin, state::State, traits::Trait,
+};


### PR DESCRIPTION
This PR adds a `DynamicPin which can change direction at runtime. I've also taken the liberty to refactor some duplicate code into helpers.

Also adds an example that demonstrates how to use these.

The current limitation is that the pin id is still baked into a DynamicPin's type, which makes it difficult to e.g. pass a bunch of these around in a collection to pick and reconfigure them at runtime. I'm working on a solution for this that's probably a breaking change to this PR, but am only ~halfway there.