### PR TITLE
mrt-Ticks: add conversion to u32

### DIFF
--- a/src/mrt.rs
+++ b/src/mrt.rs
@@ -229,6 +229,13 @@ impl Ticks {
     pub unsafe fn from_u32(value: u32) -> Self {
         Self(value)
     }
+
+    /// Returns the number of ticks of this `Tick` instance.
+    /// This method is provided as a fallback to avoid performance overhead.
+    /// You may also use the `Into` implementations instead, if you can afford it.
+    pub fn to_u32(&self) -> u32 {
+        self.0
+    }
 }
 
 impl TryFrom<u32> for Ticks {
@@ -240,6 +247,14 @@ impl TryFrom<u32> for Ticks {
         }
 
         Ok(Self(value))
+    }
+}
+
+// Note that we don't implement `From` (which would imply `Into` as well) since `From` might fail
+// (`u32` value too big) but `Into` won't (if it fits into `Ticks`, it fits into an `u32`)
+impl Into<u32> for Ticks {
+    fn into(self) -> u32 {
+        self.0
     }
 }
 


### PR DESCRIPTION
As discussed in https://github.com/braun-embedded/embedded-test-stand/issues/108 .

I didn't make any changes to `Channel::value` and `Channel::reload_value` because to me it seemed like they delivered the right type in the situations they were used in, maybe that's a discussion for 2021 :)