### PR TITLE
Add test suite using defmt-test

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -30,8 +30,10 @@ if [ "$STABLE_CHECKS" = true ]; then
 fi
 
 function build() {
+    TARGET=$1
+
     echo ""
-    echo "### Building target $1"
+    echo "### Building target $TARGET"
     echo ""
 
     # Only run trybuild on the stable channel. Otherwise changes to compiler
@@ -43,7 +45,7 @@ function build() {
         --verbose \
         --features=$1,no-target-warning$TRYBUILD \
         --target=$HOST_TARGET
-    cargo build --verbose --features=$1-rt,no-target-warning --examples
+    cargo build --verbose --features=$TARGET-rt,no-target-warning --examples
 }
 
 build 82x

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -41,11 +41,18 @@ function build() {
     # to stable.
     [ "$STABLE_CHECKS" = true ] && TRYBUILD=",trybuild" || TRYBUILD=""
 
+    # Build and test HAL
     cargo test \
         --verbose \
         --features=$1,no-target-warning$TRYBUILD \
         --target=$HOST_TARGET
     cargo build --verbose --features=$TARGET-rt,no-target-warning --examples
+
+    # Build test suite
+    (
+        cd test-suite
+        cargo build ---tests --features=$TARGET
+    )
 }
 
 build 82x

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -e
+
+# Run unit tests (from the test-suite/ directory) directly on the device
+#
+# If called without argments, unit tests for all targets are run. This requires
+# all required dev boards to be connected.
+#
+# If only one target should be tested, it must be passed as an argument:
+# - ./scripts/test.sh 82x
+# - ./scripts/test.sh 845
+
+# The user can optionally pass the target to run the tests for.
+TARGET=$1
+
+function test() {
+    TARGET=$1
+
+    echo ""
+    echo "### Testing target $TARGET"
+    echo ""
+
+    # Select probe-run configuration
+    [ "$TARGET" == "82x" ] && \
+        export PROBE_RUN_CHIP=LPC824M201JHI33 && \
+        export PROBE_RUN_PROBE=0d28:0204
+    [ "$TARGET" == "845" ] && \
+        export PROBE_RUN_CHIP=LPC845M301JHI48 && \
+        export PROBE_RUN_PROBE=1fc9:0132
+
+    # Set linker configuration. We have to do this from here, using an
+    # environment variable, as otherwise the different Cargo configuration files
+    # will interact in weird ways. Setting the rustc flags in an environment
+    # variable overrides all `rustflags` keys in Cargo configuration, so we have
+    # full control here.
+    export RUSTFLAGS="\
+        -C linker=flip-link \
+        -C link-arg=-Tlink.x \
+        -C link-arg=-Tdefmt.x
+    "
+
+    (
+        cd test-suite &&
+        cargo test -p tests --features="$TARGET")
+}
+
+if [ -n "$TARGET" ]; then
+    test $TARGET
+else
+    test "82x"
+    test "845"
+fi

--- a/test-suite/.cargo/config.toml
+++ b/test-suite/.cargo/config.toml
@@ -1,0 +1,6 @@
+[build]
+target = "thumbv6m-none-eabi"
+
+[target."thumbv6m-none-eabi"]
+runner = "probe-run"
+# This is not the full configuration. See `scripts/test.sh`.

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -1,0 +1,70 @@
+[workspace]
+members = ["tests"]
+
+
+[package]
+name    = "test-suite"
+version = "0.1.0"
+authors = ["Hanno Braun <hanno@braun-embedded.com>"]
+edition = "2018"
+publish = false
+
+
+[dependencies]
+defmt       = "0.1.3"
+defmt-rtt   = "0.1.0"
+defmt-test  = "0.1.1"
+panic-probe = "0.1.0"
+
+[dependencies.lpc8xx-hal]
+path     = ".."
+features = ["no-target-warning"]
+
+
+[features]
+default = ["defmt-default"]
+82x = ["lpc8xx-hal/82x-rt"]
+845 = ["lpc8xx-hal/845-rt"]
+
+# These features control log levels of `defmt`.
+defmt-default = []
+defmt-trace   = []
+defmt-debug   = []
+defmt-info    = []
+defmt-warn    = []
+defmt-error   = []
+
+
+[profile.dev]
+codegen-units    = 1
+debug            = 2
+debug-assertions = true
+incremental      = false
+opt-level        = 3
+overflow-checks  = true
+
+[profile.release]
+codegen-units    = 1
+debug            = 2
+debug-assertions = false
+incremental      = false
+lto              = "fat"
+opt-level        = 3
+overflow-checks  = false
+
+
+# Do not optimize proc-macro crates to get faster builds.
+
+[profile.dev.build-override]
+codegen-units    = 8
+debug            = false
+debug-assertions = false
+opt-level        = 0
+overflow-checks  = false
+
+[profile.release.build-override]
+codegen-units    = 8
+debug            = false
+debug-assertions = false
+opt-level        = 0
+overflow-checks  = false

--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["tests"]
+default-members = ["tests"]
 
 
 [package]

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -1,0 +1,35 @@
+# LPC8xx HAL Test Suite
+
+## About
+
+This is a unit testing suite for LPC8xx HAL, based on [defmt-test]. It is far from complete, but future contributors are invited to add tests here to test new functionality.
+
+
+## Running
+
+All of the following commands need to be executed from the repository root.
+
+To run tests for all supported targets (requires an [LPCXpresso824-MAX] and an [LPC845-BRK] to be connected via USB):
+```
+./scripts/test.sh
+```
+
+To run tests for LPC82x (requires an [LPCXpresso824-MAX] to be connected via USB):
+```
+./scripts/test.sh 82x
+```
+
+To run tests for LPC845 (requires an [LPC845-BRK] to be connected via USB):
+```
+./scripts/test.sh 845
+```
+
+
+## Troubleshooting
+
+The LPCXpresso824-MAX has been very finicky on my machine (probe not found), but it usually works when re-running it a few times. I'm not sure, if this is a local problem, or something that could be fixed in probe-rs.
+
+
+[defmt-test]: https://github.com/knurling-rs/defmt/tree/main/firmware/defmt-test
+[LPCXpresso824-MAX]: https://www.nxp.com/design/microcontrollers-developer-resources/lpcopen-libraries-and-examples/lpcxpresso824-max-board-for-lpc82x-family-mcus:OM13071
+[LPC845-BRK]: https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/lpc800-cortex-m0-plus-/lpc845-breakout-board-for-lpc84x-family-mcus:LPC845-BRK

--- a/test-suite/src/lib.rs
+++ b/test-suite/src/lib.rs
@@ -1,0 +1,17 @@
+#![no_std]
+
+use defmt_rtt as _; // global logger
+use panic_probe as _; // panic handler
+
+// // Re-export dependencies, so test suite can use them.
+// pub extern crate defmt;
+// pub extern crate lpc8xx_hal;
+
+use lpc8xx_hal::cortex_m::asm;
+
+/// Causes probe-run to exit with exit code 0
+pub fn exit() -> ! {
+    loop {
+        asm::bkpt();
+    }
+}

--- a/test-suite/tests/Cargo.toml
+++ b/test-suite/tests/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name    = "tests"
+version = "0.1.0"
+authors = ["Hanno Braun <hanno@braun-embedded.com>"]
+edition = "2018"
+publish = false
+
+
+[[test]]
+name    = "test"
+harness = false
+
+
+[dependencies]
+defmt       = "0.1.3"
+defmt-test  = "0.1.1"
+
+[dependencies.test-suite]
+path = ".."
+
+
+[features]
+default = ["defmt-trace"]
+
+# These features control log levels of `defmt`.
+defmt-default = []
+defmt-trace   = []
+defmt-debug   = []
+defmt-info    = []
+defmt-warn    = []
+defmt-error   = []

--- a/test-suite/tests/tests/test.rs
+++ b/test-suite/tests/tests/test.rs
@@ -1,0 +1,17 @@
+#![no_std]
+#![no_main]
+
+use test_suite as _;
+
+#[defmt_test::tests]
+mod tests {
+    #[test]
+    fn assert_true() {
+        assert!(true);
+    }
+
+    // #[test]
+    // fn assert_false() {
+    //     assert!(false);
+    // }
+}


### PR DESCRIPTION
I'd like to easily run tests on all target platforms after making a change, instead of having to manually run examples with different command-line arguments for each target. This pull request adds testing infrastructure based on defmt-test. The test suite only contains some dummy tests right now, to verify that the infrastructure works.

I plan on adding real tests with some changes I'm working on, but I wanted to submit this separately, in case there's anything that needs to be discussed here.