### PR TITLE
RFC: more generic Dynamic Pins

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,10 @@ name              = "gpio_dynamic"
 required-features = ["rt-selected"]
 
 [[example]]
+name              = "gpio_generic"
+required-features = ["rt-selected", "845"]
+
+[[example]]
 name              = "gpio_input"
 required-features = ["rt-selected", "845"]
 

--- a/examples/gpio_generic.rs
+++ b/examples/gpio_generic.rs
@@ -1,0 +1,73 @@
+#![no_main]
+#![no_std]
+
+extern crate panic_rtt_target;
+
+use lpc8xx_hal::{
+    cortex_m_rt::entry,
+    delay::Delay,
+    gpio::{direction::Dynamic, GpioPin, Level},
+    pins::{DynamicPinDirection, GenericPin},
+    prelude::*,
+    CorePeripherals, Peripherals,
+};
+
+#[entry]
+fn main() -> ! {
+    rtt_target::rtt_init_print!();
+
+    // Get access to the device's peripherals. Since only one instance of this
+    // struct can exist, the call to `take` returns an `Option<Peripherals>`.
+    // If we tried to call the method a second time, it would return `None`, but
+    // we're only calling it the one time here, so we can safely `unwrap` the
+    // `Option` without causing a panic.
+    let cp = CorePeripherals::take().unwrap();
+    let p = Peripherals::take().unwrap();
+
+    // Initialize the APIs of the peripherals we need.
+    let mut delay = Delay::new(cp.SYST);
+
+    let mut syscon = p.SYSCON.split();
+    let gpio = p.GPIO.enable(&mut syscon.handle);
+
+    // Select pins for all three LEDs
+    let (green_led, green_led_token) = (p.pins.pio1_0, gpio.tokens.pio1_0);
+    let (blue_led, blue_led_token) = (p.pins.pio1_1, gpio.tokens.pio1_1);
+    let (red_led, red_led_token) = (p.pins.pio1_2, gpio.tokens.pio1_2);
+
+    // Generate Generic Dynamic Pins from `Token` + `Pin`s and gather them for further batch
+    // processing.
+    let mut leds: [GpioPin<GenericPin, Dynamic>; 3] = [
+        green_led.into_generic_dynamic_pin(
+            green_led_token,
+            Level::High, // led is off initially
+            DynamicPinDirection::Output,
+        ),
+        blue_led.into_generic_dynamic_pin(
+            blue_led_token,
+            Level::High, // led is off initially
+            DynamicPinDirection::Output,
+        ),
+        red_led.into_generic_dynamic_pin(
+            red_led_token,
+            Level::High, // led is off initially
+            DynamicPinDirection::Output,
+        ),
+    ];
+
+    loop {
+        // Blink all LED colors by looping through the array that holds them
+        // This should make the on-board LED blink like this:
+        // 🟢 🔵 🔴 🟢 🔵 🔴 🟢 🔵 🔴 ...
+        for led in leds.iter_mut() {
+            blink_led(led, &mut delay);
+        }
+    }
+}
+
+/// Turn `led` on for 1000 ms
+fn blink_led(led: &mut GpioPin<GenericPin, Dynamic>, delay: &mut Delay) {
+    led.set_low();
+    delay.delay_ms(1_000_u16);
+    led.set_high();
+}

--- a/examples/pinint.rs
+++ b/examples/pinint.rs
@@ -32,11 +32,11 @@ mod app {
         let gpio = p.GPIO.enable(&mut syscon.handle);
         let pinint = p.PININT.enable(&mut syscon.handle);
 
-        let _button = p.pins.pio0_4.into_input_pin(gpio.tokens.pio0_4);
+        let button = p.pins.pio0_4.into_input_pin(gpio.tokens.pio0_4);
         let mut int = pinint
             .interrupts
             .pinint0
-            .select::<PIO0_4>(&mut syscon.handle);
+            .select::<PIO0_4>(button.inner(), &mut syscon.handle);
         int.enable_rising_edge();
         int.enable_falling_edge();
 

--- a/src/pinint/interrupt.rs
+++ b/src/pinint/interrupt.rs
@@ -1,8 +1,8 @@
 use core::marker::PhantomData;
 
-use crate::{init_state::Enabled, pac, pins, syscon};
-
 use super::traits::Trait;
+
+use crate::{init_state::Enabled, pac, pins, syscon};
 
 /// API for controlling pin interrupts
 pub struct Interrupt<I, P, State> {
@@ -42,7 +42,11 @@ where
     /// interrupts is reused for other purposes.
     ///
     /// [open an issue]: https://github.com/lpc-rs/lpc8xx-hal/issues
-    pub fn select<P>(self, _: &mut syscon::Handle) -> Interrupt<I, P, State>
+    pub fn select<P>(
+        self,
+        interrupt_pin: &P,
+        _: &mut syscon::Handle,
+    ) -> Interrupt<I, P, State>
     where
         P: pins::Trait,
     {
@@ -55,7 +59,7 @@ where
         syscon.pintsel[I::INDEX].write(|w|
             // Sound, as any value with `0 <= value <= 63` is valid to write to
             // the register.
-            unsafe { w.intpin().bits(32 * P::PORT as u8 + P::ID) });
+            unsafe { w.intpin().bits(32 * interrupt_pin.port() as u8 + interrupt_pin.id())});
 
         Interrupt {
             interrupt: self.interrupt,

--- a/src/pins/gen.rs
+++ b/src/pins/gen.rs
@@ -6,10 +6,10 @@ use super::{pin::Pin, state, traits::Trait};
 
 macro_rules! pins {
     ($(
-        $field:ident,
-        $type:ident,
+        $field:ident, // e.g. pio0_0
+        $type:ident,  // e.g. PIO0_0
         $port:expr,
-        $id:expr,
+        $id:expr,     // e.g. 0x00
         $default_state_ty:ty;
     )*) => {
         /// Provides access to all pins
@@ -55,9 +55,17 @@ macro_rules! pins {
             pub struct $type(());
 
             impl Trait for $type {
-                const PORT: usize = $port;
-                const ID  : u8    = $id;
-                const MASK: u32   = 0x1 << $id;
+                fn port(&self) -> usize {
+                    $port
+                }
+
+                fn id(&self) -> u8 {
+                    $id
+                }
+
+                fn mask(&self) -> u32 {
+                    0x1 << $id
+                }
             }
         )*
 
@@ -79,7 +87,7 @@ macro_rules! pins {
             pub(crate) fn new() -> Self {
                 Self {
                     $(
-                        $field: Token($type(()), PhantomData),
+                        $field: Token(PhantomData, PhantomData),
                     )*
                 }
             }
@@ -97,13 +105,13 @@ macro_rules! pins {
             }
         }
 
-        /// A token representing a pin
+        /// A token representing a pin.
         ///
         /// Used by [`GPIO`] to uphold correctness guarantees. Please refer to
         /// [`GPIO`] for more information.
         ///
         /// [`GPIO`]: ../gpio/struct.GPIO.html
-        pub struct Token<T, State>(T, PhantomData<State>);
+        pub struct Token<Pin, State>(PhantomData<Pin>, PhantomData<State>);
     }
 }
 

--- a/src/pins/mod.rs
+++ b/src/pins/mod.rs
@@ -12,5 +12,6 @@ mod traits;
 pub mod state;
 
 pub use self::{
-    gen::*, pin::DynamicPinDirection, pin::Pin, state::State, traits::Trait,
+    gen::*, pin::DynamicPinDirection, pin::GenericPin, pin::Pin, state::State,
+    traits::Trait,
 };

--- a/src/pins/traits.rs
+++ b/src/pins/traits.rs
@@ -8,14 +8,14 @@
 ///
 /// [`Pin`]: struct.Pin.html
 pub trait Trait {
-    /// A number that indentifies the port
+    /// Get the number that indentifies the port
     ///
     /// This is `0` for PIO0 pins (e.g. [`PIO0_0`]) and `1` for PIO1 pins (e.g.
     /// [`PIO1_0`]).
     ///
     /// [`PIO0_0`]: struct.PIO0_0.html
     /// [`PIO1_0`]: struct.PIO1_0.html
-    const PORT: usize;
+    fn port(&self) -> usize; // TODO make u8
 
     /// A number that identifies the pin
     ///
@@ -23,7 +23,7 @@ pub trait Trait {
     ///
     /// [`PIO0_0`]: struct.PIO0_0.html
     /// [`PIO0_1`]: struct.PIO0_1.html
-    const ID: u8;
+    fn id(&self) -> u8;
 
     /// The pin's bit mask
     ///
@@ -33,5 +33,5 @@ pub trait Trait {
     /// [`PIO0_0`]: struct.PIO0_0.html
     /// [`PIO0_1`]: struct.PIO0_1.html
     /// [`PIO0_2`]: struct.PIO0_2.html
-    const MASK: u32;
+    fn mask(&self) -> u32;
 }

--- a/src/swm/movable_functions.rs
+++ b/src/swm/movable_functions.rs
@@ -114,10 +114,9 @@ macro_rules! impl_function {
         impl FunctionTrait<pins::$pin> for $type {
             type Kind = $kind;
 
-            fn assign(&mut self, _pin: &mut pins::$pin, swm: &mut Handle) {
+            fn assign(&mut self, pin: &mut pins::$pin, swm: &mut Handle) {
                 swm.swm.$reg_name.modify(|_, w| unsafe {
-                    w.$reg_field()
-                        .bits(pins::$pin::ID | (pins::$pin::PORT as u8) << 5)
+                    w.$reg_field().bits(pin.id() | (pin.port() as u8) << 5)
                 });
             }
 


### PR DESCRIPTION
Hi everyone,
the goal of this PR is more to start a discussion rather than getting it merged as-is (as you can see, there's quite a lot of Doc TODOs in there anyway).
The code in this PR... works (I've been using it [in my test-stand fork](https://github.com/Lotterleben/lpc845-test-stand/tree/generic_dynamic_pin) ; beware– there's a lot of code in dire need of cleanup in there), but I'm not convinced it is the best solution.

The problem it tries to solve is:
Currently, Pin IDs are baked into each pin type. This limits the applicability of Dynamic GPIO Pins: While I can define pins to be changeable at runtime (for example in a Test stand context to re-configure the LPC from test case to test case), I can't gather them in a vector, or define functions like `fn initialize_pin(pin: GpioPin<??, Direction::Dynamic>)`, and handling these `Direction::Dynamic` pins involves verbose match statements and repetitive code, which introduce clutter.

The approach in this PR is to define a new type `DynamicGpioPin<D>`, which moves `port` and `mask` out of the `Token` baked into `GpioPin`s and into the `DynamicGpioPin` struct fields. The downside to this is that the usage differs from the usage of `GpioPin`s, there's potentially a bit more code and helpers like `is_high<T: pins::Trait>` (which I've *just* introduced :D) won't work anymore– though this may be fixable with some macros maybe?

So, my discussion questions would be:
- is this a viable approach? If so, it would make sense to get rid of `GpioPin<T, direction::Dynamic>`, no?
- are there other ways to resolve this which you'd prefer over the sketch in this PR?