### PR TITLE
`pins::Trait`: downsize to `u8`

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -474,7 +474,7 @@ where
         let gpio = unsafe { &*pac::GPIO::ptr() };
         let registers = Registers::new(gpio);
 
-        registers.not[self.inner().port()]
+        registers.not[usize::from(self.inner().port())]
             .write(|w| unsafe { w.notp().bits(self.inner().mask()) });
     }
 }
@@ -822,17 +822,21 @@ pub enum Level {
 }
 
 fn set_high(registers: &Registers, inner: &impl pins::Trait) {
-    registers.set[inner.port()]
+    registers.set[usize::from(inner.port())]
         .write(|w| unsafe { w.setp().bits(inner.mask()) });
 }
 
 fn set_low(registers: &Registers, inner: &impl pins::Trait) {
-    registers.clr[inner.port()]
+    registers.clr[usize::from(inner.port())]
         .write(|w| unsafe { w.clrp().bits(inner.mask()) });
 }
 
 fn is_high(registers: &Registers, inner: &impl pins::Trait) -> bool {
-    registers.pin[inner.port()].read().port().bits() & inner.mask()
+    registers.pin[usize::from(inner.port())]
+        .read()
+        .port()
+        .bits()
+        & inner.mask()
         == inner.mask()
 }
 
@@ -840,7 +844,7 @@ fn is_high(registers: &Registers, inner: &impl pins::Trait) -> bool {
 // Use the direction helpers of `GpioPin<P, direction::Output>` and `GpioPin<P, direction::Dynamic>`
 // instead.
 fn set_direction_output(registers: &Registers, inner: &impl pins::Trait) {
-    registers.dirset[inner.port()]
+    registers.dirset[usize::from(inner.port())]
         .write(|w| unsafe { w.dirsetp().bits(inner.mask()) });
 }
 
@@ -848,7 +852,7 @@ fn set_direction_output(registers: &Registers, inner: &impl pins::Trait) {
 // Use the direction helpers of `GpioPin<P, direction::Input>` and `GpioPin<P, direction::Dynamic>`
 // instead.
 fn set_direction_input(registers: &Registers, inner: &impl pins::Trait) {
-    registers.dirclr[inner.port()]
+    registers.dirclr[usize::from(inner.port())]
         .write(|w| unsafe { w.dirclrp().bits(inner.mask()) });
 }
 

--- a/src/pins/gen.rs
+++ b/src/pins/gen.rs
@@ -55,7 +55,7 @@ macro_rules! pins {
             pub struct $type(());
 
             impl Trait for $type {
-                fn port(&self) -> usize {
+                fn port(&self) -> u8 {
                     $port
                 }
 

--- a/src/pins/pin.rs
+++ b/src/pins/pin.rs
@@ -184,7 +184,7 @@ pub struct Pin<T: Trait, S: State> {
 /// [`pins::Token`]: struct.Token.html
 /// [`pins::Trait`]: trait.Trait.html
 pub struct GenericPin {
-    port: usize, // todo make u8
+    port: u8,
     id: u8,
 }
 
@@ -532,13 +532,13 @@ where
 
 impl GenericPin {
     /// Creates a new `GenericPin`
-    pub(super) fn new(port: usize, id: u8) -> Self {
+    pub(super) fn new(port: u8, id: u8) -> Self {
         Self { port, id }
     }
 }
 
 impl Trait for GenericPin {
-    fn port(&self) -> usize {
+    fn port(&self) -> u8 {
         self.port
     }
 

--- a/src/pins/traits.rs
+++ b/src/pins/traits.rs
@@ -15,7 +15,7 @@ pub trait Trait {
     ///
     /// [`PIO0_0`]: struct.PIO0_0.html
     /// [`PIO1_0`]: struct.PIO1_0.html
-    fn port(&self) -> usize; // TODO make u8
+    fn port(&self) -> u8;
 
     /// A number that identifies the pin
     ///


### PR DESCRIPTION
as promised, resize `pins::Trait` to `u8`

Based on https://github.com/lpc-rs/lpc8xx-hal/pull/305 ; so:
- ~relevant commit is the second one: https://github.com/lpc-rs/lpc8xx-hal/commit/8d91838fa454241790c546756866c07f5332b157~
- ~should be rebased & only merged after #305 is merged~