### PR TITLE
Improve USART error handling

### DIFF
--- a/src/usart/peripheral.rs
+++ b/src/usart/peripheral.rs
@@ -487,7 +487,7 @@ where
     I: Instance,
     W: Word,
 {
-    type Error = Error;
+    type Error = Error<W>;
 
     /// Reads a single word from the serial interface
     fn read(&mut self) -> nb::Result<W, Self::Error> {

--- a/src/usart/rx.rs
+++ b/src/usart/rx.rs
@@ -253,7 +253,7 @@ where
     I: Instance,
     W: Word,
 {
-    type Error = Error;
+    type Error = Error<W>;
 
     fn read(&mut self) -> nb::Result<W, Self::Error> {
         // Sound, as we're only reading from `stat`, and `rxdatstat` is
@@ -271,20 +271,22 @@ where
             // it changes the status flags.
             let rx_dat_stat = usart.rxdatstat.read();
 
+            let word = Word::from_u16(rx_dat_stat.rxdat().bits());
+
             if stat.overrunint().bit_is_set() {
                 usart.stat.write(|w| w.overrunint().set_bit());
-                Err(nb::Error::Other(Error::Overrun))
+                Err(nb::Error::Other(Error::Overrun(word)))
             } else if rx_dat_stat.framerr().bit_is_set() {
                 usart.stat.write(|w| w.framerrint().set_bit());
-                Err(nb::Error::Other(Error::Framing))
+                Err(nb::Error::Other(Error::Framing(word)))
             } else if rx_dat_stat.parityerr().bit_is_set() {
                 usart.stat.write(|w| w.parityerrint().set_bit());
-                Err(nb::Error::Other(Error::Parity))
+                Err(nb::Error::Other(Error::Parity(word)))
             } else if rx_dat_stat.rxnoise().bit_is_set() {
                 usart.stat.write(|w| w.rxnoiseint().set_bit());
-                Err(nb::Error::Other(Error::Noise))
+                Err(nb::Error::Other(Error::Noise(word)))
             } else {
-                Ok(Word::from_u16(rx_dat_stat.rxdat().bits()))
+                Ok(word)
             }
         } else {
             Err(nb::Error::WouldBlock)
@@ -329,16 +331,16 @@ where
 
 /// A USART error
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Error {
+pub enum Error<Word> {
     /// Character received with a stop bit missing at the expected location
-    Framing,
+    Framing(Word),
 
     /// Corrupted character received
-    Noise,
+    Noise(Word),
 
     /// Character received, while receive buffer was still in use
-    Overrun,
+    Overrun(Word),
 
     /// Parity error detected in received character
-    Parity,
+    Parity(Word),
 }

--- a/src/usart/rx.rs
+++ b/src/usart/rx.rs
@@ -272,12 +272,16 @@ where
             let rx_dat_stat = usart.rxdatstat.read();
 
             if stat.overrunint().bit_is_set() {
+                usart.stat.write(|w| w.overrunint().set_bit());
                 Err(nb::Error::Other(Error::Overrun))
             } else if rx_dat_stat.framerr().bit_is_set() {
+                usart.stat.write(|w| w.framerrint().set_bit());
                 Err(nb::Error::Other(Error::Framing))
             } else if rx_dat_stat.parityerr().bit_is_set() {
+                usart.stat.write(|w| w.parityerrint().set_bit());
                 Err(nb::Error::Other(Error::Parity))
             } else if rx_dat_stat.rxnoise().bit_is_set() {
+                usart.stat.write(|w| w.rxnoiseint().set_bit());
                 Err(nb::Error::Other(Error::Noise))
             } else {
                 Ok(Word::from_u16(rx_dat_stat.rxdat().bits()))


### PR DESCRIPTION
I've verified that receiving characters via USART still works with this code. But I don't have a setup that would allow me to inject errors, so I can't test whether this has the intended effect. All feedback is appreciated!

Close #307