### PR TITLE
gpio.rs: add get_level()

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1030,7 +1030,7 @@ pub mod direction {
     }
 
     /// Error that can be thrown by operations on a Dynamic pin
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, Debug)]
     pub enum DynamicPinErr {
         /// you called a function that is not applicable to the pin's current direction
         WrongDirection,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -238,7 +238,7 @@ where
     }
 
     /// Indicates wether the voltage at the pin is currently HIGH
-    /// This is not accessible to the user to avoid confusion becauzse `is_high()`
+    /// This is not accessible to the user to avoid confusion because `is_high()`
     /// semantics differ depending on pin direction. It is only used to implement
     /// `is_high()` and `is_set_high()` respectively for the different direction types.
     pub(crate) fn is_high_inner(&self) -> bool {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -345,24 +345,6 @@ where
     pub fn get_level(&self) -> Level {
         Level::from_pin(&self)
     }
-
-    /// Returns the current voltage level at this pin.
-    ///
-    /// This method is only available, if two conditions are met:
-    /// - The pin is in the GPIO state.
-    /// - The pin direction is set to input.
-    ///
-    /// See [`Pin::into_input_pin`] and [`into_input`]. Unless both of these
-    /// conditions are met, code trying to call this method will not compile.
-    ///
-    /// [`Pin::into_input_pin`]: ../pins/struct.Pin.html#method.into_input_pin
-    /// [`into_input`]: #method.into_input
-    pub fn get_level(&self) -> Level {
-        match self.is_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
-    }
 }
 
 impl<P> GpioPin<P, direction::Output>
@@ -641,22 +623,6 @@ where
     /// Unless this condition is met, code trying to call this method will not compile.
     pub fn get_level(&self) -> Level {
         Level::from_pin(&self)
-    }
-
-    /// Returns the current voltage level at this pin.
-    /// This can be used when the pin is in any direction:
-    ///
-    /// If it is currently an Output pin, it indicates to which level the pin is set
-    /// If it is currently an Input pin, it indicates the level currently present at this pin
-    ///
-    /// This method is only available, if the pin has been set to dynamic mode.
-    /// See [`Pin::into_dynamic_pin`].
-    /// Unless this condition is met, code trying to call this method will not compile.
-    pub fn get_level(&self) -> Level {
-        match self.is_high() {
-            true => Level::High,
-            false => Level::Low,
-        }
     }
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -345,6 +345,24 @@ where
     pub fn get_level(&self) -> Level {
         Level::from_pin(&self)
     }
+
+    /// Returns the current voltage level at this pin.
+    ///
+    /// This method is only available, if two conditions are met:
+    /// - The pin is in the GPIO state.
+    /// - The pin direction is set to input.
+    ///
+    /// See [`Pin::into_input_pin`] and [`into_input`]. Unless both of these
+    /// conditions are met, code trying to call this method will not compile.
+    ///
+    /// [`Pin::into_input_pin`]: ../pins/struct.Pin.html#method.into_input_pin
+    /// [`into_input`]: #method.into_input
+    pub fn get_level(&self) -> Level {
+        match self.is_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
+    }
 }
 
 impl<P> GpioPin<P, direction::Output>
@@ -473,6 +491,24 @@ where
     /// [`into_output`]: #method.into_output
     pub fn is_set_low(&self) -> bool {
         !self.is_set_high()
+    }
+
+    /// Returns the level to which this pin is currently set
+    ///
+    /// This method is only available, if two conditions are met:
+    /// - The pin is in the GPIO state.
+    /// - The pin direction is set to output.
+    ///
+    /// See [`Pin::into_output_pin`] and [`into_output`]. Unless both of these
+    /// conditions are met, code trying to call this method will not compile.
+    ///
+    /// [`Pin::into_output_pin`]: ../pins/struct.Pin.html#method.into_output_pin
+    /// [`into_output`]: #method.into_output
+    pub fn get_set_level(&self) -> Level {
+        match self.is_set_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
     }
 
     /// Toggle the pin output
@@ -605,6 +641,22 @@ where
     /// Unless this condition is met, code trying to call this method will not compile.
     pub fn get_level(&self) -> Level {
         Level::from_pin(&self)
+    }
+
+    /// Returns the current voltage level at this pin.
+    /// This can be used when the pin is in any direction:
+    ///
+    /// If it is currently an Output pin, it indicates to which level the pin is set
+    /// If it is currently an Input pin, it indicates the level currently present at this pin
+    ///
+    /// This method is only available, if the pin has been set to dynamic mode.
+    /// See [`Pin::into_dynamic_pin`].
+    /// Unless this condition is met, code trying to call this method will not compile.
+    pub fn get_level(&self) -> Level {
+        match self.is_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
     }
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -327,6 +327,24 @@ where
     pub fn is_low(&self) -> bool {
         !self.is_high()
     }
+
+    /// Returns the current voltage level at this pin.
+    ///
+    /// This method is only available, if two conditions are met:
+    /// - The pin is in the GPIO state.
+    /// - The pin direction is set to input.
+    ///
+    /// See [`Pin::into_input_pin`] and [`into_input`]. Unless both of these
+    /// conditions are met, code trying to call this method will not compile.
+    ///
+    /// [`Pin::into_input_pin`]: ../pins/struct.Pin.html#method.into_input_pin
+    /// [`into_input`]: #method.into_input
+    pub fn get_level(&self) -> Level {
+        match self.is_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
+    }
 }
 
 impl<P> GpioPin<P, direction::Output>
@@ -455,6 +473,24 @@ where
     /// [`into_output`]: #method.into_output
     pub fn is_set_low(&self) -> bool {
         !self.is_set_high()
+    }
+
+    /// Returns the level to which this pin is currently set
+    ///
+    /// This method is only available, if two conditions are met:
+    /// - The pin is in the GPIO state.
+    /// - The pin direction is set to output.
+    ///
+    /// See [`Pin::into_output_pin`] and [`into_output`]. Unless both of these
+    /// conditions are met, code trying to call this method will not compile.
+    ///
+    /// [`Pin::into_output_pin`]: ../pins/struct.Pin.html#method.into_output_pin
+    /// [`into_output`]: #method.into_output
+    pub fn get_set_level(&self) -> Level {
+        match self.is_set_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
     }
 
     /// Toggle the pin output
@@ -591,6 +627,22 @@ where
     /// Unless this condition is met, code trying to call this method will not compile.
     pub fn is_low(&self) -> bool {
         !self.is_high()
+    }
+
+    /// Returns the current voltage level at this pin.
+    /// This can be used when the pin is in any direction:
+    ///
+    /// If it is currently an Output pin, it indicates to which level the pin is set
+    /// If it is currently an Input pin, it indicates the level currently present at this pin
+    ///
+    /// This method is only available, if the pin has been set to dynamic mode.
+    /// See [`Pin::into_dynamic_pin`].
+    /// Unless this condition is met, code trying to call this method will not compile.
+    pub fn get_level(&self) -> Level {
+        match self.is_high() {
+            true => Level::High,
+            false => Level::Low,
+        }
     }
 }
 


### PR DESCRIPTION
Hi 👋,
I've found myself creating match statements like these

```
let pinint0_level = match pinint0_pin.is_high() {
    true => pin::Level::High,
    false => pin::Level::Low,
};
```

more often than I'd like, and imo it'd be neat to resolve this at the HAL level.
So this PR adds a native `get_level()` (or `get_set_level()` in the case of `Output` pins) function to make the level directly accessible.