### PR TITLE
Upgrade to latest RTIC alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ default-features = false
 
 
 [dev-dependencies]
-cortex-m-rtic = "=0.6.0-alpha.0"
+cortex-m-rtic = "=0.6.0-alpha.1"
 
 [dev-dependencies.panic-rtt-target]
 version  = "0.1.1"

--- a/examples/i2c_master_slave.rs
+++ b/examples/i2c_master_slave.rs
@@ -25,7 +25,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> init::LateResources {
+    fn init(_: init::Context) -> (init::LateResources, init::Monotonics) {
         rtt_target::rtt_init_print!();
 
         let p = Peripherals::take().unwrap();
@@ -56,10 +56,13 @@ mod app {
             ..Default::default()
         });
 
-        init::LateResources {
-            i2c_master: i2c.master,
-            i2c_slave: i2c.slave,
-        }
+        (
+            init::LateResources {
+                i2c_master: i2c.master,
+                i2c_slave: i2c.slave,
+            },
+            init::Monotonics(),
+        )
     }
 
     #[idle(resources = [i2c_master])]

--- a/examples/i2c_master_slave_dma.rs
+++ b/examples/i2c_master_slave_dma.rs
@@ -29,7 +29,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> init::LateResources {
+    fn init(_: init::Context) -> (init::LateResources, init::Monotonics) {
         rtt_target::rtt_init_print!();
 
         let p = Peripherals::take().unwrap();
@@ -61,11 +61,14 @@ mod app {
             ..Default::default()
         });
 
-        init::LateResources {
-            i2c_master: Some(i2c.master),
-            i2c_slave: i2c.slave,
-            dma_channel: Some(dma.channels.channel15),
-        }
+        (
+            init::LateResources {
+                i2c_master: Some(i2c.master),
+                i2c_slave: i2c.slave,
+                dma_channel: Some(dma.channels.channel15),
+            },
+            init::Monotonics(),
+        )
     }
 
     #[idle(resources = [i2c_master, dma_channel])]

--- a/examples/pinint.rs
+++ b/examples/pinint.rs
@@ -23,7 +23,7 @@ mod app {
     }
 
     #[init]
-    fn init(_: init::Context) -> init::LateResources {
+    fn init(_: init::Context) -> (init::LateResources, init::Monotonics) {
         rtt_target::rtt_init_print!();
 
         let p = Peripherals::take().unwrap();
@@ -45,7 +45,7 @@ mod app {
             .pio1_1
             .into_output_pin(gpio.tokens.pio1_1, Level::High);
 
-        init::LateResources { int, led }
+        (init::LateResources { int, led }, init::Monotonics())
     }
 
     #[idle]

--- a/examples/rtic.rs
+++ b/examples/rtic.rs
@@ -23,7 +23,7 @@ mod app {
     }
 
     #[init]
-    fn init(cx: init::Context) -> init::LateResources {
+    fn init(cx: init::Context) -> (init::LateResources, init::Monotonics) {
         rtt_target::rtt_init_print!();
 
         let p = Peripherals::take().unwrap();
@@ -38,7 +38,7 @@ mod app {
             .pio1_1
             .into_output_pin(gpio.tokens.pio1_1, Level::Low);
 
-        init::LateResources { delay, led }
+        (init::LateResources { delay, led }, init::Monotonics())
     }
 
     #[idle(resources = [delay, led])]


### PR DESCRIPTION
The build was broken due to the release of the new RTIC alpha version.
We pin a specific RTIC version in Cargo.toml to prevent just that, but
that won't prevent Cargo from happily picking up breaking changes from
transitive dependencies. Since RTIC consists of multiple crates, that is
what happened here.

We could explicitly specify and pin all those transitive dependencies in
Cargo.toml to prevent that from happening, but that would get unwieldy.
I decided that it's probably best to just upgrade to the latest alpha,
ride it out for this alpha cycle, and be more careful about adding alpha
dependencies in the future.