### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ travis-ci = { repository = "lpc-rs/lpc8xx-hal" }
 
 
 [dependencies]
-cortex-m      = "0.6.4"
+cortex-m      = "0.7.2"
 embedded-time = "0.10.1"
 nb            = "1.0.0"
 
@@ -47,11 +47,11 @@ package = "embedded-hal"
 
 [dependencies.lpc82x-pac]
 optional = true
-version  = "0.7.0"
+version  = "0.8.0"
 
 [dependencies.lpc845-pac]
 optional = true
-version  = "0.3.0"
+version  = "0.4.0"
 
 [dependencies.num-traits]
 version          = "0.2.14"

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -13,7 +13,6 @@ use crate::{
     init_state::Enabled,
     pac::{
         dma0::channel::xfercfg::{DSTINC_A, SRCINC_A},
-        generic::Variant,
         i2c0::{stat::MSTSTATE_A, MSTCTL, MSTDAT},
     },
     reg_proxy::{Reg, RegProxy},
@@ -112,7 +111,9 @@ where
             Error::read::<I>()?;
         }
 
-        let actual = i2c.stat.read().mststate().variant().try_into();
+        let mststate = i2c.stat.read().mststate();
+        let actual =
+            mststate.variant().try_into().map_err(|()| mststate.bits());
         if Ok(&expected) != actual.as_ref() {
             return Err(Error::UnexpectedState { expected, actual });
         }
@@ -347,18 +348,18 @@ pub enum State {
     NackData,
 }
 
-impl TryFrom<Variant<u8, MSTSTATE_A>> for State {
+impl TryFrom<Option<MSTSTATE_A>> for State {
     /// The value of the MSTSTATE field, if unexpected
-    type Error = u8;
+    type Error = ();
 
-    fn try_from(state: Variant<u8, MSTSTATE_A>) -> Result<Self, Self::Error> {
+    fn try_from(state: Option<MSTSTATE_A>) -> Result<Self, Self::Error> {
         match state {
-            Variant::Val(MSTSTATE_A::IDLE) => Ok(Self::Idle),
-            Variant::Val(MSTSTATE_A::RECEIVE_READY) => Ok(Self::RxReady),
-            Variant::Val(MSTSTATE_A::TRANSMIT_READY) => Ok(Self::TxReady),
-            Variant::Val(MSTSTATE_A::NACK_ADDRESS) => Ok(Self::NackAddress),
-            Variant::Val(MSTSTATE_A::NACK_DATA) => Ok(Self::NackData),
-            Variant::Res(bits) => Err(bits),
+            Some(MSTSTATE_A::IDLE) => Ok(Self::Idle),
+            Some(MSTSTATE_A::RECEIVE_READY) => Ok(Self::RxReady),
+            Some(MSTSTATE_A::TRANSMIT_READY) => Ok(Self::TxReady),
+            Some(MSTSTATE_A::NACK_ADDRESS) => Ok(Self::NackAddress),
+            Some(MSTSTATE_A::NACK_DATA) => Ok(Self::NackData),
+            None => Err(()),
         }
     }
 }

--- a/src/i2c/master.rs
+++ b/src/i2c/master.rs
@@ -349,7 +349,6 @@ pub enum State {
 }
 
 impl TryFrom<Option<MSTSTATE_A>> for State {
-    /// The value of the MSTSTATE field, if unexpected
     type Error = ();
 
     fn try_from(state: Option<MSTSTATE_A>) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Upgrades to the new versions of the PACs (see https://github.com/lpc-rs/lpc-pac/pull/57). I did some light testing on LPC845 by running some of the examples, and didn't see any problems. Since this is about all I have time for right now, I suggest leaving it at that and letting problems shake out in master (if there are any problems; the SVD files stayed the same, so I don't expect anything major).

Currently blocked on new released of `lpc82x-pac` and `lpc845-pac`.