### PR TITLE
Upgrade to latest PAC versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,13 @@ package = "embedded-hal"
 
 [dependencies.lpc82x-pac]
 optional = true
-version  = "0.8.0"
+git      = "https://github.com/lpc-rs/lpc-pac.git"
+# version  = "0.8.0"
 
 [dependencies.lpc845-pac]
 optional = true
-version  = "0.4.0"
+git      = "https://github.com/lpc-rs/lpc-pac.git"
+# version  = "0.4.0"
 
 [dependencies.num-traits]
 version          = "0.2.14"


### PR DESCRIPTION
Upgrade to latest versions of the PACs. Tested by running a few of the examples. I don't expect any regressions, since the changes aren't substantial.

Submitted as a draft. I plan to update this to use published versions, once they are out.