### PR TITLE
Update dependency on cortex-m-rt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ version  = "1.0.35"
 optional = true
 
 [dependencies.cortex-m-rt]
-version  = "0.6.13"
+version  = ">=0.6.15, <0.8"
 optional = true
 
 [dependencies.embedded-hal]


### PR DESCRIPTION
We aren't affected by the breaking changes of the 0.7 release. The PAC
has already been updated to accept both 0.6 and 0.7, so this leaves it
up to the user which version to use.