### PR TITLE
Upgrade to latest RTIC release candidate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ default-features = false
 
 
 [dev-dependencies]
-cortex-m-rtic = "=0.6.0-alpha.5"
+cortex-m-rtic = "0.6.0-rc.2"
 
 [dev-dependencies.panic-rtt-target]
 version  = "0.1.1"


### PR DESCRIPTION
This also relaxes the version requirement (no longer pins to a specific
version), as no more breaking changes are to be expected after a release
candidate.